### PR TITLE
Untitled

### DIFF
--- a/easy_thumbnails/source_generators.py
+++ b/easy_thumbnails/source_generators.py
@@ -3,7 +3,10 @@ try:
 except ImportError:
     from StringIO import StringIO
 
-from PIL import Image
+try:
+    from PIL import Image
+except ImportError:
+    import Image
 
 
 def pil_image(source, **options):


### PR DESCRIPTION
solution for "ImportError: No module named PIL" on windows
