### PR TITLE
tag() method didn't work

### DIFF
--- a/easy_thumbnails/files.py
+++ b/easy_thumbnails/files.py
@@ -108,7 +108,7 @@ class ThumbnailFile(ImageFieldFile):
         fake_field = FakeField(storage=storage)
         super(ThumbnailFile, self).__init__(FakeInstance(), fake_field, name,
                                             *args, **kwargs)
-        del self.field
+#        del self.field
         if file:
             self.file = file
 


### PR DESCRIPTION
I took out the _del self.field_ line as it was causing an error when trying to use the tag() method. Haven't noticed any problems from taking it out yet...  I guess the point of deleting it was to prevent people using that attr without realising it doesn't work like on a regular FieldFile?

the self.field attr itself seemed to be useful in the tag method, not sure if there's another way to get the same info...
