### PR TITLE
Set zip_safe to false, so a buildout deployed egg will still work with So

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,4 +49,5 @@ setup(
         'Topic :: Software Development :: Libraries :: Application Frameworks',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
+    zip_safe = False,
 )


### PR DESCRIPTION
Set zip_safe to false, so a buildout deployed egg will still work with South migrations.
South cannot currently find the migrations, as buildout is zipping the egg.
