### PR TITLE
If thumbnails not found in database tables, optionally asks the storage. (updated, with tests)

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -101,7 +101,7 @@ THUMBNAIL_SOURCE_GENERATORS
 		)
 
 	The :doc:`source_generators` through which the base image is created from
-	the source file. 
+	the source file.
 
 	The order of the processors is the order in which they are sequentially
 	tried.
@@ -123,3 +123,15 @@ THUMBNAIL_TRANSPARENCY_EXTENSION
 
 	The type of image to save thumbnails with a transparency layer (e.g. GIFs
 	or transparent PNGs).
+
+THUMBNAIL_CHECK_CACHE_MISS
+	Default: ``False``
+
+	If this boolean setting is set to ``True``, and a thumbnail cannot
+    be found in the database tables, we ask the storage if it has the
+    thumbnail. If it does we add the row in the database, and we don't
+    need to generate the thumbnail.
+
+    Switch this to True if your easy_thumbnails_thumbnail table has been wiped
+    but your storage still has the thumbnail files.
+

--- a/easy_thumbnails/defaults.py
+++ b/easy_thumbnails/defaults.py
@@ -20,3 +20,5 @@ PROCESSORS = (
 SOURCE_GENERATORS = (
     'easy_thumbnails.source_generators.pil_image',
 )
+CHECK_CACHE_MISS = False
+

--- a/easy_thumbnails/files.py
+++ b/easy_thumbnails/files.py
@@ -21,7 +21,7 @@ def get_thumbnailer(object, relative_name=None):
     The ``object`` argument is usually either one of the following:
 
         * ``FieldFile`` instance (i.e. a model instance file/image field
-          property). 
+          property).
 
         * ``File`` or ``Storage`` instance, and for both of these cases the
           ``relative_name`` argument must also be provided
@@ -231,6 +231,7 @@ class Thumbnailer(File):
     thumbnail_extension = utils.get_setting('EXTENSION')
     thumbnail_transparency_extension = utils.get_setting(
                                                     'TRANSPARENCY_EXTENSION')
+    thumbnail_check_cache_miss = utils.get_setting('CHECK_CACHE_MISS')
     source_generators = None
     thumbnail_processors = None
 
@@ -378,7 +379,8 @@ class Thumbnailer(File):
             update_modified = update_modified or datetime.datetime.utcnow()
         return models.Source.objects.get_file(
             create=create, update_modified=update_modified,
-            storage=self.source_storage, name=self.name)
+            storage=self.source_storage, name=self.name,
+            check_cache_miss=self.thumbnail_check_cache_miss)
 
     def get_thumbnail_cache(self, thumbnail_name, create=False, update=False):
         modtime = self.get_thumbnail_modtime(thumbnail_name)
@@ -388,7 +390,8 @@ class Thumbnailer(File):
         source = self.get_source_cache(create=True)
         return models.Thumbnail.objects.get_file(
             create=create, update_modified=update_modified,
-            storage=self.thumbnail_storage, source=source, name=thumbnail_name)
+            storage=self.thumbnail_storage, source=source, name=thumbnail_name,
+            check_cache_miss=self.thumbnail_check_cache_miss)
 
     def get_source_modtime(self):
         try:

--- a/easy_thumbnails/tests/__init__.py
+++ b/easy_thumbnails/tests/__init__.py
@@ -2,3 +2,4 @@ from easy_thumbnails.tests.fields import ThumbnailerFieldTest
 from easy_thumbnails.tests.files import FilesTest
 from easy_thumbnails.tests.processors import ScaleAndCropTest
 from easy_thumbnails.tests.templatetags import ThumbnailTagTest
+from easy_thumbnails.tests.models import FileManagerTest

--- a/easy_thumbnails/tests/models.py
+++ b/easy_thumbnails/tests/models.py
@@ -1,0 +1,85 @@
+"""Tests for the models module.
+"""
+
+from StringIO import StringIO
+
+from django.core.files.base import ContentFile
+try:
+    from PIL import Image
+except ImportError:
+    import Image
+
+from easy_thumbnails import utils
+from easy_thumbnails.models import Thumbnail, Source
+from easy_thumbnails.tests import utils as test_utils
+
+class FileManagerTest(test_utils.BaseTest):
+    """Test for FileManager"""
+
+    def setUp(self):
+        super(FileManagerTest, self).setUp()
+
+        self.storage = test_utils.TemporaryStorage()
+        self.storage_hash = utils.get_storage_hash(self.storage)
+        self.source = Source.objects.create(
+                name='Test source',
+                storage_hash=self.storage_hash)
+
+        # Generate a test image, save it.
+        data = StringIO()
+        Image.new('RGB', (800, 600)).save(data, 'JPEG')
+        data.seek(0)
+        image_file = ContentFile(data.read())
+        self.filename = self.storage.save('test.jpg', image_file)
+
+    def tearDown(self):
+        self.storage.delete_temporary_storage()
+        super(FileManagerTest, self).tearDown()
+
+    def test_create_file(self):
+        """Create a new Thumbnail in the database"""
+        img = Thumbnail.objects.get_file(
+                self.storage,
+                self.filename,
+                create=True,
+                source=self.source)
+
+        self.assertEquals(img.name, self.filename)
+
+    def test_get_file(self):
+        """Fetch an existing thumb from database"""
+        created = Thumbnail.objects.create(
+                storage_hash=self.storage_hash,
+                name=self.filename,
+                source=self.source)
+
+        fetched = Thumbnail.objects.get_file(
+                self.storage,
+                self.filename,
+                create=False)
+
+        self.assertTrue(fetched)
+        self.assertEquals(created, fetched)
+
+    def test_get_file_check_cache(self):
+        """Fetch a thumb that is in the storage but not in the database"""
+
+        # It's not in the database yet
+        try:
+            Thumbnail.objects.get(name=self.filename)
+            self.fail('Thumb should not exist yet')
+        except Thumbnail.DoesNotExist:
+            pass
+
+        Thumbnail.objects.get_file(
+                self.storage,
+                self.filename,
+                source=self.source,
+                check_cache_miss=True)
+
+        # Now it is
+        try:
+            Thumbnail.objects.get(name=self.filename)
+        except Thumbnail.DoesNotExist:
+            self.fail('Thumb should exist now')
+


### PR DESCRIPTION
If FileManager.get_file can't find the thumb, optionally ask the storage and rebuild db cache if found. New setting to switch on that check. Tests.
