### PR TITLE
Fix broken pypi install by including README.rst in the manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
+include LICENSE
+include README.rst
 recursive-include docs *.txt *.py *.bat *.


### PR DESCRIPTION
```
$ pip install easy-thumbnails==1.0-alpha-19

...

Traceback (most recent call last):

  File "<string>", line 14, in <module>

  File "/Users/brandon/.virtualenvs/myapp/build/easy-thumbnails/setup.py", line 27, in <module>

    long_description=read_files('README.rst'),

  File "/Users/brandon/.virtualenvs/myapp/build/easy-thumbnails/setup.py", line 13, in read_files

    f = open(filename)

IOError: [Errno 2] No such file or directory: 'README.rst'
```
