### PR TITLE
Epic new functionality allows for predefined image alternatives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ dist
 build
 docs/_build
 .tox/
-*.egg
+*.egg*
 reports/*
+*.pyc

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,4 @@
+Authors
+
+- Chris Beaven <?> http://smileychris.com/
+- Daniel Sokolowski <daniel.sokolowski@danols.com> www.danols.com

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,9 @@
 Easy Thumbnails
 ===============
 
-The powerful, yet easy to implement thumbnailing application for Django.
+The powerful, yet easy to implement thumbnailing application for Django. Below is a quick summary of usage,
+For a complete documenations please see "full documenation":http://easy-thumbnails.readthedocs.org/en/latest/index.html
+or the documenation *docs/* folder. 
 
 To install this application into your project, just add it to your
 ``INSTALLED_APPS`` setting (and run ``manage.py syncdb``)::
@@ -15,6 +17,42 @@ To install this application into your project, just add it to your
 
 Template usage
 ==============
+
+There are two ways to generate thumbnails in a template. One is to use the template {% thumbnail %} tag the other is 
+to use image 'alternatives'  that you define on the image field itself, {{ foo_instance.image.large }}.
+
+Image Alternatives
+------------------
+To take advantage of dynamic image alternatives generation use ``ThumbnailerImageField`` for your model image fields and specify
+the settings like in a similiar fassion as below::
+
+   image = ThumbnailerImageField(
+        upload_to=get_upload_path, 
+        # reduce the original only if needed keeping aspect ratio and  highest quality
+        'process_source': dict(size=(0, 1080), quality=100),
+        # we use alternatives instead of original so that thumbnail/image settings 
+        # such us JPEG quiality can be quickly adjusted for the whole site
+        alternatives = {
+            'thumbnail_small': dict(size=(100, 100), autocrop=True, crop='smart', detail=True, upscale=True), 
+            'thumbnail_medium': dict(size=(160, 160), autocrop=True, crop='smart', detail=True, upscale=True), 
+            'thumbnail_large': dict(size=(220,220), autocrop=True, crop='smart', detail=True, upscale=True),
+            'small': dict(size=(0, 480), crop=True, upscale=True),
+            'medium': dict(size=(0, 600), crop=True, upscale=True),
+            'large': dict(size=(0, 720), crop=True, upscale=True),
+            'all_settings_sample': dict(size=(0, 720), quality=100, autocrop=True, bw=True, crop=True, detail=True, replace_alpha='#fff', sharpen=True, upscale=True),
+        }
+    )
+    
+Then in your template you can reffer to the specified altenratives as so::
+
+   <a href='{{productimage.image.large.url}}'>
+   <img class='product media thumbnail medium' alt='{{productimage.image.name}} - {{productimage.image.description}}' 
+        src='{{productimage.image.thumbnail_medium.url}}' >
+   </a>
+
+
+Tempplate Tag Usage
+-------------------
 
 To generate thumbnails in your template, use the ``{% thumbnail %}`` tag. To
 make this tag available for use in your template, use::
@@ -49,20 +87,33 @@ the image to a thumbnail such as ``sharpen``, ``crop`` and ``quality=90``.
 Model usage
 ===========
 
-You can use the ``ThumbnailerField`` or ``ThumbnailerImageField`` fields (based
+You can use the ``ThumbnailerField`` or ``EasyImageField`` fields (based
 on ``FileField`` and ``ImageField``, respectively) for easier access to
-retrieve (or generate) thumbnail images.
+retrieve (or generate) thumbnail images. 
 
-By passing a ``resize_source`` argument to the ``ThumbnailerImageField``, you
-can resize the source image before it is saved::
+By passing a ``process_source`` and ``alternatives`` arguments to the ``ThumbnailerImageField``, you
+can resize the source image on save and provide quick image alternatives in your python code or templates::
 
-    class Profile(models.Model):
-        user = models.ForeignKey('auth.User')
-        avatar = ThumbnailerImageField(
-            upload_to='avatars',
-            resize_source=dict(size=(50, 50), crop='smart'),
-        )
+   from easy_thumbnails.fields import ThumbnailerImageField
+   class Profile(models.Model):
+      user = models.ForeignKey('auth.User')
+      avatar = EasyImageField(
+         upload_to='avatars',
+         process_source=dict(size=(0, 720), quality=95, autocrop=True, bw=False, crop=True, detail=False, replace_alpha=False, sharpen=False, upscale=True),
+         alternatives = {
+            'small': dict(size=(100, 134), autocrop=True, crop=True, upscale=True), 
+            'medium': dict(size=(160, 214), autocrop=True, crop=True, upscale=True), 
+            'large': dict(size=(220, 294), autocrop=True, crop=True, upscale=True), 
+        }
+    )
 
+Then you can utilize you alternatives in your python code like so::
+    
+   >>> Profile.objects.all()[0].avatar.large
+   <ThumbnailFile: accounts/profile/image-4.jpg.220x294_q85_autocrop_crop_upscale.jpg>
+   >>> ProductCategory.objects.all()[0].get_image().image.small
+   <ThumbnailFile: accounts/profile/image-4.jpg.100x134_q85_autocrop_crop_upscale.jpg>
+   
 
 Lower level usage
 =================
@@ -77,3 +128,9 @@ the ``get_thumbnailer`` method to generate one of these, for example::
         return get_thumbnailer(source).get_thumbnail(thumbnail_options)
 
 See the docs directory for more comprehensive usage documentation.
+
+Image Processors
+================
+
+For a list of avaiable processing options and how to specify custom image processors please see the :doc:`ref/processors` reference
+documentation.

--- a/docs/install.txt
+++ b/docs/install.txt
@@ -50,5 +50,13 @@ In your Django project's settings module, add easy-thumbnails to your
         'easy_thumbnails',
     )
 
+Next create the two tables in your database that are required by running::
+
+	$  python manage.py syncdb
+	...
+	Creating table easy_thumbnails_source
+	Creating table easy_thumbnails_thumbnail
+	...
+	
 You may also want to set up some :doc:`easy-thumbnails related settings
 <ref/settings>`.

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -59,10 +59,10 @@ THUMBNAIL_SUBDIR
 	Save thumbnail images to a sub-directory relative to the source image.
 
 	For example, using the ``{% thumbnail "photos/1.jpg" 150x150 %}`` tag with
-	a ``THUMBNAIL_SUBDIR`` of ``'thumbs'`` would result in the following
+	a ``THUMBNAIL_SUBDIR`` of ``'easy_thumbnails'`` would result in the following
 	thumbnail filename::
 
-		MEDIA_ROOT + 'photos/thumbs/1_jpg_150x150_q85.jpg'
+		MEDIA_ROOT + 'photos/easy_thumbnails/1_jpg_150x150_q85.jpg'
 
 THUMBNAIL_PREFIX
 	Default: ``''``

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -59,8 +59,40 @@ make this tag available for use in your template, use::
 
 .. autofunction:: easy_thumbnails.templatetags.thumbnail.thumbnail
 
+Image alternatives
+------------------
+
+To take advantage of dynamic image alternatives generation use ``ThumbnailerImageField`` for your 
+model image fields and specify the settings like in the example below::
+
+   image = EasyImageField(
+        upload_to=get_upload_path, 
+        # reduce the original only if needed keeping aspect ratio and  highest quality
+        'process_source': dict(size=(0, 1080), quality=100),
+        # we use alternatives instead of original so that thumbnail/image settings 
+        # such us JPEG quiality can be quickly adjusted for the whole site
+        alternatives = {
+            'thumbnail_small': dict(size=(100, 100), autocrop=True, crop='smart', detail=True, upscale=True), 
+            'thumbnail_medium': dict(size=(160, 160), autocrop=True, crop='smart', detail=True, upscale=True), 
+            'thumbnail_large': dict(size=(220,220), autocrop=True, crop='smart', detail=True, upscale=True),
+            'small': dict(size=(0, 480), crop=True, upscale=True),
+            'medium': dict(size=(0, 600), crop=True, upscale=True),
+            'large': dict(size=(0, 720), crop=True, upscale=True),
+            'all_settings_sample': dict(size=(0, 720), quality=100, autocrop=True, bw=True, crop=True, detail=True, replace_alpha='#fff', sharpen=True, upscale=True),
+        }
+    )
+    
+Then in your template you can reffer to the specified altenratives as so: 
+
+   <a href='{{productimage.image.large.url}}'>
+   <img class='product media thumbnail medium' alt='{{productimage.image.name}} - {{productimage.image.description}}' 
+        src='{{productimage.image.thumbnail_medium.url}}' >
+   </a>
+
 For a full list of options, read the :doc:`ref/processors` reference
 documentation.
+
+
 
 
 Models
@@ -70,6 +102,29 @@ You can use the ``ThumbnailerField`` or ``ThumbnailerImageField`` fields (based
 on ``FileField`` and ``ImageField``, respectively) for easier access to
 retrieve (or generate) thumbnail images, use different storages and resize
 source images before saving.
+
+By passing a ``process_source`` and ``alternatives`` arguments to the ``ThumbnailerImageField``, you
+can resize the source image on save and provide quick image alternatives in your python code or templates::
+
+   from easy_thumbnails.fields import EasyImageField
+   class Profile(models.Model):
+      user = models.ForeignKey('auth.User')
+      avatar = EasyImageField(
+         upload_to='avatars',
+         process_source=dict(size=(0, 720), quality=95, autocrop=True, bw=False, crop=True, detail=False, replace_alpha=False, sharpen=False, upscale=True),
+         alternatives = {
+            'small': dict(size=(100, 134), autocrop=True, crop=True, upscale=True), 
+            'medium': dict(size=(160, 214), autocrop=True, crop=True, upscale=True), 
+            'large': dict(size=(220, 294), autocrop=True, crop=True, upscale=True), 
+        }
+    )
+
+Then you can utilize you alternatives in your python code like so::
+    
+   >>> Profile.objects.all()[0].avatar.large
+   <ThumbnailFile: accounts/profile/image-4.jpg.220x294_q85_autocrop_crop_upscale.jpg>
+   >>> ProductCategory.objects.all()[0].get_image().image.small
+   <ThumbnailFile: accounts/profile/image-4.jpg.100x134_q85_autocrop_crop_upscale.jpg>
 
 .. autoclass:: easy_thumbnails.fields.ThumbnailerField
 

--- a/easy_thumbnails/fields.py
+++ b/easy_thumbnails/fields.py
@@ -1,6 +1,7 @@
 from django.db.models.fields.files import FileField, ImageField
 from easy_thumbnails import files
-
+import warnings
+from django.core.exceptions import ImproperlyConfigured
 
 class ThumbnailerField(FileField):
     """
@@ -29,19 +30,19 @@ class ThumbnailerField(FileField):
         return (field_class, args, kwargs)
 
 
-class ThumbnailerImageField(ThumbnailerField, ImageField):
+class EasyImageField(ThumbnailerField, ImageField):
     """
     An image field which provides easier access for retrieving (and generating)
-    thumbnails.
+    thumbnails or other defined image alternatives.
 
-    To use a different file storage for thumbnails, provide the
+    To use a different file storage for iamge alternatives , provide the
     ``thumbnail_storage`` keyword argument.
 
-    To thumbnail the original source image before saving, provide the
-    ``resize_source`` keyword argument, passing it a usual thumbnail option
+    To process the original source image before saving, provide the
+    ``process_source`` keyword argument, passing it a usual alternative option
     dictionary. For example::
 
-        ThumbnailField(..., resize_source=dict(size=(100, 100), sharpen=True))
+        EasyImageField(..., process_source=dict(size=(100, 100), sharpen=True))
     """
     attr_class = files.ThumbnailerImageFieldFile
 
@@ -49,8 +50,16 @@ class ThumbnailerImageField(ThumbnailerField, ImageField):
         # Arguments not explicitly defined so that the normal ImageField
         # positional arguments can be used.
         self.resize_source = kwargs.pop('resize_source', None)
+        self.process_source = kwargs.pop('process_source', None)
+        if self.resize_source and self.process_source:
+            raise ImproperlyConfigured("You can not have both 'resize_source' and 'process_source' arguments specified.")
+        elif not self.resize_source is None: #elif self.resize_source != None:
+            warnings.warn("``resize_source`` option is being depreciated in favor of more generic ``process_source`` name.", DeprecationWarning)
+            self.process_source = self.resize_source
+            del self.resize_source
+        self.alternatives = kwargs.pop('alternatives', None)
+        super(EasyImageField, self).__init__(*args, **kwargs)
 
-        super(ThumbnailerImageField, self).__init__(*args, **kwargs)
 
     def south_field_triple(self):
         """
@@ -60,3 +69,11 @@ class ThumbnailerImageField(ThumbnailerField, ImageField):
         field_class = 'django.db.models.fields.files.ImageField'
         args, kwargs = introspector(self)
         return (field_class, args, kwargs)
+
+class ThumbnailerImageField(EasyImageField):
+    """
+    Place holder to allow for backwards compatibility
+    """
+    def __init__(self, *args, **kwargs):
+        warnings.warn("'ThumbnailerImageField' class is being depreciated in favor of more generic 'EasyImageField' name.", DeprecationWarning)
+        super(ThumbnailerImageField, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Image alternatives are defined using the EasyImageField field's settings. Once configured the generated images can be accessed both through python or a template system::

```
>>> Profile.objects.all()[0].avatar.large
<ThumbnailFile: accounts/profile/image-4.jpg.220x294_q85_autocrop_crop_upscale.jpg>

<a href={{profile.avatar.large.url}}><img alt='Profile' src='{{profile.avatar.thumbnail_small.url}}'></a>
```

Other enhancements include:
    \* Updated naming convention with backwards compatibility (ThumbnailerImageField => EasyImageField, resize_source => process_source)
    \* Updated/corrected/created documentations and authors.
