### PR TITLE
Use Django's default storage for thumbnails

### DIFF
--- a/easy_thumbnails/fields.py
+++ b/easy_thumbnails/fields.py
@@ -1,4 +1,5 @@
 from django.db.models.fields.files import FileField, ImageField
+from django.core.files.storage import default_storage
 from easy_thumbnails import files
 
 
@@ -15,7 +16,7 @@ class ThumbnailerField(FileField):
     def __init__(self, *args, **kwargs):
         # Arguments not explicitly defined so that the normal ImageField
         # positional arguments can be used.
-        self.thumbnail_storage = kwargs.pop('thumbnail_storage', None)
+        self.thumbnail_storage = kwargs.pop('thumbnail_storage', default_storage)
 
         super(ThumbnailerField, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION
When no storage is passed as argument for the ThumbnailerImageField, use Django's default storage, since the global setting for it exists DEFAULT_FILE_STORAGE 
