### PR TITLE
initial widget fix

### DIFF
--- a/easy_thumbnails/tests/widgets.py
+++ b/easy_thumbnails/tests/widgets.py
@@ -1,6 +1,7 @@
 from easy_thumbnails import widgets
 from easy_thumbnails.files import get_thumbnailer
 from easy_thumbnails.tests import utils as test_utils
+from django.forms.widgets import ClearableFileInput
 
 
 class ImageClearableFileInput(test_utils.BaseTest):
@@ -76,3 +77,13 @@ class ImageClearableFileInput(test_utils.BaseTest):
         self.assertIn(source_filename, html)
         self.assertIn('.80x80_', html)
         self.assertIn('FOO', html)
+
+    def test_render_without_value(self):
+        """
+        If value not passed, use super widget.
+        """
+        widget = widgets.ImageClearableFileInput()
+        base_widget = ClearableFileInput()
+        html = widget.render('photo', None)
+        base_html = base_widget.render('photo', None)
+        self.assertEqual(base_html, html)

--- a/easy_thumbnails/widgets.py
+++ b/easy_thumbnails/widgets.py
@@ -28,13 +28,13 @@ class ImageClearableFileInput(ClearableFileInput):
         return thumbnailer.get_thumbnail(self.thumbnail_options)
 
     def render(self, name, value, attrs=None):
-        if value:
-            thumb = self.get_thumbnail(value)
-            substitution = {
-                'template': super(ImageClearableFileInput, self).render(name,
-                    value, attrs),
-                'thumb': thumb.tag(id=self.thumbnail_id(name)),
-                'source_url': value.storage.url(value.name),
-            }
-            return mark_safe(self.template_with_thumbnail % substitution)
-        return super(ImageClearableFileInput, self).render(name, value, attrs)
+        output = super(ImageClearableFileInput, self).render(name, value, attrs)
+        if not value:
+            return output
+        thumb = self.get_thumbnail(value)
+        substitution = {
+            'template': output,
+            'thumb': thumb.tag(id=self.thumbnail_id(name)),
+            'source_url': value.storage.url(value.name),
+        }
+        return mark_safe(self.template_with_thumbnail % substitution)


### PR DESCRIPTION
Your widget has error when value is None, because it's trying to get name attribute.

Also is it okay, that widget looks not very pretty in admin by default? (django 1.4)
http://cl.ly/0v150A150V1L1V1N2g2R
Look "clear" label and checkbox, than file input align by checkbox.
