### PR TITLE
Fallback to importing django.conf.Settings instead of BaseSettings

### DIFF
--- a/easy_thumbnails/conf.py
+++ b/easy_thumbnails/conf.py
@@ -1,5 +1,8 @@
-from django.conf import BaseSettings
 from django.conf import settings as django_settings
+try:
+    from django.conf import BaseSettings
+except ImportError:  # Django <= 1.2
+    from django.conf import Settings as BaseSettings
 
 
 class AppSettings(BaseSettings):


### PR DESCRIPTION
As suggested in issue #148 this should fix easy-thumbnails on older Django versions. Completely untested (used the web interface to make this change).
