### PR TITLE
I get an IOError instead of OSError

### DIFF
--- a/easy_thumbnails/utils.py
+++ b/easy_thumbnails/utils.py
@@ -115,7 +115,7 @@ def exif_orientation(im):
     """
     try:
         exif = im._getexif()
-    except (AttributeError, IndexError, KeyError, OSError):
+    except (AttributeError, IndexError, KeyError, IOError):
         exif = None
     if exif:
         orientation = exif.get(0x0112)


### PR DESCRIPTION
When testing better i get IOError instead of OSError. OSError should be handled as well?

This handles well the corrupted image reported at #151
