### PR TITLE
Utilize the modified_time function implemented by Storage classes instead of assuming thumbnail storages are path-based and manually using os.path to calculate mod times

### DIFF
--- a/easy_thumbnails/files.py
+++ b/easy_thumbnails/files.py
@@ -434,7 +434,7 @@ class Thumbnailer(File):
         if self.remote_source:
             return None
         modtime = self.get_source_modtime()
-        update_modified = modtime and utils.fromtimestamp(modtime)
+        update_modified = modtime #and utils.fromtimestamp(modtime)
         if update:
             update_modified = update_modified or utils.now()
         return models.Source.objects.get_file(
@@ -446,7 +446,7 @@ class Thumbnailer(File):
         if self.remote_source:
             return None
         modtime = self.get_thumbnail_modtime(thumbnail_name)
-        update_modified = modtime and utils.fromtimestamp(modtime)
+        update_modified = modtime #and utils.fromtimestamp(modtime)
         if update:
             update_modified = update_modified or utils.now()
         source = self.get_source_cache(create=True)
@@ -457,8 +457,7 @@ class Thumbnailer(File):
 
     def get_source_modtime(self):
         try:
-            path = self.source_storage.path(self.name)
-            return os.path.getmtime(path)
+            return self.source_storage.modified_time(self.name)
         except OSError:
             return 0
         except NotImplementedError:
@@ -466,8 +465,7 @@ class Thumbnailer(File):
 
     def get_thumbnail_modtime(self, thumbnail_name):
         try:
-            path = self.thumbnail_storage.path(thumbnail_name)
-            return os.path.getmtime(path)
+            return self.thumbnail_storage.modified_time(thumbnail_name)
         except OSError:
             return 0
         except NotImplementedError:


### PR DESCRIPTION
As you're aware, modtimes are critical for the thumbnail_exists method (and much of the framework) to operate correctly.  Currently,  get_source_modtime & get_thumbnail_modtime, in files.py (line 461 & 470), are hardcoded to use os.path.getmtime(path) to get the modtimes for thumbnails and sources.  However, this assumes an os.path compatible Storage backend and neglects the fact that Django Storage classes and subclasses already implement a "modified_time" method for this purpose. 

I've written a database base64-based storage backend & a memcached storage backend (with fall-back to database) in order to do various things on Heroku, which has an ephemeral file-system that is useless for writing files to.  I have my reasons for doing this instead of uploading to S3. 

As it stands, easy-thumbnails doesn't work out of the box with these backends because of the os.path usage.  However, there was no reason why it couldn't work with any storage backend that implements the modified_time interface which Django's Storage prescribes.  FileSystemStorage (and by extension ThumbnailFileSystemStorage) already implement modified_time by doing basically the same thing easy-thumbnails manually does (see django.core.files.storage.FileSystemStorage):

```
def modified_time(self, name):
        return datetime.fromtimestamp(os.path.getmtime(self.path(name)))
```

In sum, it seems more correct to use the storage's modified_time method rather than manually getting the modified time, and this enables different types of backends. 

My fork swaps out the hardcoded called to os.path and calls the storage's modified_time method instead.  Also, the call to utils.fromtimestamp in `update_modified = modtime and utils.fromtimestamp(modtime)` at lines 437 and 449 become redundant, since the modified_time method in FileSystemStorage performs this conversion already for file based storages.  

All tests pass, and I don't really see room for new tests beyond the current ones, since this is using the modified_time method of Django Storage or FileSystemStorage (or of a custom storage) which are tested in their respective packages.    But i'd be happy to write a test if you can describe to me what it would do.  Anecdotally, I've been using this code in production for a few months without issue. 
