### PR TITLE
Use modified_time method provided by Storage interface instead of assuming os.path compatible storages when getting mod times

### DIFF
--- a/easy_thumbnails/files.py
+++ b/easy_thumbnails/files.py
@@ -441,7 +441,7 @@ class Thumbnailer(File):
         if self.remote_source:
             return None
         modtime = self.get_source_modtime()
-        update_modified = modtime and utils.fromtimestamp(modtime)
+        update_modified = modtime and utils.make_time_zone_aware(modtime)
         if update:
             update_modified = update_modified or utils.now()
         return models.Source.objects.get_file(
@@ -453,7 +453,7 @@ class Thumbnailer(File):
         if self.remote_source:
             return None
         modtime = self.get_thumbnail_modtime(thumbnail_name)
-        update_modified = modtime and utils.fromtimestamp(modtime)
+        update_modified = modtime and utils.make_time_zone_aware(modtime)
         if update:
             update_modified = update_modified or utils.now()
         source = self.get_source_cache(create=True)
@@ -463,22 +463,10 @@ class Thumbnailer(File):
             check_cache_miss=self.thumbnail_check_cache_miss)
 
     def get_source_modtime(self):
-        try:
-            path = self.source_storage.path(self.name)
-            return os.path.getmtime(path)
-        except OSError:
-            return 0
-        except NotImplementedError:
-            return None
+        return utils.get_modified_time(self.source_storage, self.name)
 
     def get_thumbnail_modtime(self, thumbnail_name):
-        try:
-            path = self.thumbnail_storage.path(thumbnail_name)
-            return os.path.getmtime(path)
-        except OSError:
-            return 0
-        except NotImplementedError:
-            return None
+        return utils.get_modified_time(self.thumbnail_storage, thumbnail_name)
 
     def open(self, mode=None):
         if self.closed:

--- a/easy_thumbnails/utils.py
+++ b/easy_thumbnails/utils.py
@@ -1,6 +1,7 @@
 import inspect
 import math
 import datetime
+import os
 
 from django.utils.functional import LazyObject
 
@@ -18,8 +19,7 @@ try:
     from django.utils import timezone
     now = timezone.now
 
-    def fromtimestamp(timestamp):
-        dt = datetime.datetime.fromtimestamp(timestamp)
+    def make_time_zone_aware(dt):
         if getattr(settings, 'USE_TZ', False):
             default_timezone = timezone.get_default_timezone()
             return timezone.make_aware(dt, default_timezone)
@@ -27,7 +27,7 @@ try:
 
 except ImportError:
     now = datetime.datetime.now
-    fromtimestamp = datetime.datetime.fromtimestamp
+    make_time_zone_aware = lambda dt: dt
 
 from easy_thumbnails.conf import settings
 
@@ -140,3 +140,20 @@ def exif_orientation(im):
         elif orientation == 8:
             im = im.rotate(90)
     return im
+
+
+def get_modified_time(storage, name):
+    """
+    Get modified time from storage if the storage implements modified_time.
+    Fall back to using os.path (assumes a FS-based storage) for backwards-compatibility
+    """
+    try:
+        try:
+            return storage.modified_time(name)
+        except AttributeError: # older storage interface didn't have "modified_time"
+            path = storage.path(name)
+            return datetime.datetime.fromtimestamp(os.path.getmtime(path))
+    except OSError:
+        return 0
+    except NotImplementedError:
+        return None


### PR DESCRIPTION
As you're aware, checking file modified times is currently critical for the thumbnail_exists method (and much of the framework) to operate correctly. Currently, get_source_modtime & get_thumbnail_modtime, in files.py (line 461 & 470), are hardcoded to use os.path.getmtime to get the modtimes for thumbnails and sources. However, this assumes an os.path compatible Storage backend and neglects the fact that the Django Storage interface defines a "modified_time" method for this purpose.

As it stands, easy-thumbnails doesn't work out of the box with some custom storages because of the os.path assumption. However, there was no reason why easy-thumbnails couldn't work with any storage backend that implements the modified_time interface which Django's Storage prescribes. FileSystemStorage (and by extension ThumbnailFileSystemStorage) already implement modified_time by doing basically the same thing easy-thumbnails manually does (see django.core.files.storage.FileSystemStorage):

`def modified_time(self, name):
        return datetime.fromtimestamp(os.path.getmtime(self.path(name)))`

In sum, it seems more correct to use the storage's modified_time method rather than manually getting the modified time, and this enables different types of backends.

My commit swaps out the hardcoded call to os.path and calls the storage's modified_time method instead. Also, the call to `utils.fromtimestamp` at lines 437 and 449 become redundant, since the modified_time method in FileSystemStorage performs time stamp conversion already for file-based storages.

All tests pass, and I don't really see room for new tests beyond the current ones, since this is using the modified_time method of Django Storage or FileSystemStorage (or of a custom storage) which are tested in their respective packages. But i'd be happy to write a test if you can describe to me what it would do. Anecdotally, I've been using this code in production for a few months and it works great.
