### PR TITLE
Fixed deprecation warning

### DIFF
--- a/easy_thumbnails/utils.py
+++ b/easy_thumbnails/utils.py
@@ -3,7 +3,12 @@ import math
 import datetime
 
 from django.utils.functional import LazyObject
-from django.utils.hashcompat import md5_constructor
+
+try:
+    from hashlib import md5 as md5_constructor
+except ImportError:
+    from django.utils.hashcompat import md5_constructor
+
 try:
     from PIL import Image
 except ImportError:


### PR DESCRIPTION
`django.utils.hashcompat` is deprecated as of Django 1.5. Use `hashlib` instead.
