### PR TITLE
`hashcompat` is deprecated as of Django 1.5

### DIFF
--- a/easy_thumbnails/migrations/0012_build_storage_hashes.py
+++ b/easy_thumbnails/migrations/0012_build_storage_hashes.py
@@ -4,8 +4,12 @@ from south.db import db
 from south.v2 import DataMigration
 from django.db import models
 from django.core.files.storage import default_storage
-from django.utils.hashcompat import md5_constructor
 import pickle
+try:
+    from hashlib import md5 as md5_constructor
+except ImportError:
+    from django.utils.hashcompat import md5_constructor
+
 
 class Migration(DataMigration):
     """

--- a/easy_thumbnails/migrations/0013_auto__del_storage__del_field_source_storage__del_field_thumbnail_stora.py
+++ b/easy_thumbnails/migrations/0013_auto__del_storage__del_field_source_storage__del_field_thumbnail_stora.py
@@ -5,7 +5,11 @@ from south.v2 import SchemaMigration
 from django.db import models
 from django.core.files.storage import default_storage
 import pickle
-from django.utils.hashcompat import md5_constructor
+try:
+    from hashlib import md5 as md5_constructor
+except ImportError:
+    from django.utils.hashcompat import md5_constructor
+
 
 class Migration(SchemaMigration):
 


### PR DESCRIPTION
Pullrequest #187 missed the use of hashcompat in these two migrations
