### PR TITLE
Don't retrieve extra fields not needed in case they are defered in find_uncommitted_filefields

### DIFF
--- a/easy_thumbnails/signal_handlers.py
+++ b/easy_thumbnails/signal_handlers.py
@@ -11,7 +11,12 @@ def find_uncommitted_filefields(sender, instance, **kwargs):
     :func:`signal_committed_filefields` post_save handler.
     """
     uncommitted = instance._uncommitted_filefields = []
-    for field in sender._meta.fields:
+    
+    fields = sender._meta.fields
+    if kwargs.get('update_fields', None):
+        update_fields = set(kwargs['update_fields'])
+        fields = update_fields.intersection(fields)
+    for field in fields:
         if isinstance(field, FileField):
             if not getattr(instance, field.name)._committed:
                 uncommitted.append(field.name)


### PR DESCRIPTION
If a user issues a save with the update_fields argument (Django 1.5), it is not necessary to check other fields in find_uncommitted_filefields, and doing so when those fields are deferred results in extra queries.

Since it checks for existance of update_fields argument, this is compatible with previous versions of django as well.
