### PR TITLE
Fixed the tox tests

### DIFF
--- a/easy_thumbnails/conf.py
+++ b/easy_thumbnails/conf.py
@@ -18,7 +18,10 @@ class AppSettings(BaseSettings):
         self.isolated = isolated
         self._changed = {}
         self._added = []
-        super(AppSettings, self).__init__(*args, **kwargs)
+        try:
+            super(AppSettings, self).__init__(django_settings.SETTINGS_MODULE, **kwargs)
+        except TypeError:
+            super(AppSettings, self).__init__(*args, **kwargs)
 
     def get_isolated(self):
         return self._isolated

--- a/easy_thumbnails/test_settings.py
+++ b/easy_thumbnails/test_settings.py
@@ -5,6 +5,8 @@ SITE_ID = 1
 MEDIA_ROOT = os.path.normcase(os.path.dirname(os.path.abspath(__file__)))
 MEDIA_URL = '/media/'
 
+SECRET_KEY = 'key-for-testing'
+
 DATABASE_ENGINE = 'sqlite3'
 
 DATABASES = {

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,9 @@ basepython = python2.5
 deps =
     Django==1.2.4
     PIL
+setenv =
+    DJANGO_SETTINGS_MODULE = easy_thumbnails.test_settings
+    PIP_INSECURE = 1
 
 [testenv:py26-1.2.X]
 basepython = python2.6
@@ -47,6 +50,9 @@ basepython = python2.5
 deps =
     Django==1.3.1
     PIL
+setenv =
+    DJANGO_SETTINGS_MODULE = easy_thumbnails.test_settings
+    PIP_INSECURE = 1
 
 [testenv:py26-1.3.X]
 basepython = python2.6
@@ -64,17 +70,20 @@ deps =
 [testenv:py25]
 basepython = python2.5
 deps =
-    https://github.com/django/django/zipball/master
+    https://www.djangoproject.com/download/1.4.5/tarball/
     PIL
+setenv =
+    DJANGO_SETTINGS_MODULE = easy_thumbnails.test_settings
+    PIP_INSECURE = 1
 
 [testenv:py26]
 basepython = python2.6
 deps =
-    https://github.com/django/django/zipball/master
+    https://www.djangoproject.com/download/1.5.1/tarball/
     PIL
 
 [testenv:py27]
 basepython = python2.7
 deps =
-    https://github.com/django/django/zipball/master
+    https://www.djangoproject.com/download/1.5.1/tarball/
     PIL


### PR DESCRIPTION
- Added `PIP_INSECURE = 1` to all the Python 2.5 environments so packages would install.
- Changed the `py25` env so it uses the last version of Django that supports Python 2.5
- Changed the `py26` and `py27` envs so they use Django 1.5.1
- It should be noted that non of the environments that use Django 1.2.X pass anymore. This is most likely because of commit 6d5d9cc which added the widget `django.forms.widgets.ClearableFileInput` that was new in Django 1.3.X. Maybe easy-thumbnails should consider dropping support for Python 2.5 and Django 1.2.X.
