### PR TITLE
The overridden url property is no longer necessary.

### DIFF
--- a/easy_thumbnails/files.py
+++ b/easy_thumbnails/files.py
@@ -6,7 +6,6 @@ import os
 
 from django.utils.safestring import mark_safe
 from django.utils.html import escape
-from django.utils.http import urlquote
 
 from easy_thumbnails import engine, exceptions, models, utils, signals
 from easy_thumbnails.alias import aliases


### PR DESCRIPTION
The issue which the property was circumventing was fixed in django revision https://github.com/django/django/commit/090ff642043a2ca7d69e475f721eab4d68f6572b#django/core/files/storage.py

The overridden property also had the following bug:

If used with storages that return urls that specify the protocol (ex: http://foo.com/bar#comment)
then the protocol separator (:) is also quoted resulting in a broken urls such as: 
http **%3A** //foo.com/bar%23comment
