### PR TITLE
Allow {% thumbnail %} 'size' to be an alias name. See #248.

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -191,7 +191,9 @@ use::
 -----------------------
 
 If you want to create a thumbnail *without* providing an alias, use this tag to
-generate the thumbnail by specifying all of the required options.
+generate the thumbnail by specifying all of the required options (or *with* an
+alias name, to override/supplement the default alias options with dynamic
+content).
 
 .. autofunction:: easy_thumbnails.templatetags.thumbnail.thumbnail
 

--- a/easy_thumbnails/tests/__init__.py
+++ b/easy_thumbnails/tests/__init__.py
@@ -4,6 +4,7 @@ from easy_thumbnails.tests.processors import ScaleAndCropTest, ColorspaceTest
 from easy_thumbnails.tests.source_generators import PilImageTest
 from easy_thumbnails.tests.templatetags import (
     ThumbnailTagTest,
+    ThumbnailTagAliasTest,
     ThumbnailerFilterTest,
     ThumbnailerPassiveFilterTest,
 )

--- a/easy_thumbnails/tests/templatetags.py
+++ b/easy_thumbnails/tests/templatetags.py
@@ -283,3 +283,36 @@ class ThumbnailerPassiveFilterTest(ThumbnailerBase):
         )
         output = self.render_template(src)
         self.assertEqual(output, '')
+
+
+class ThumbnailTagAliasTest(ThumbnailerBase):
+    def assertCorrectOutput(self, src, alias_name, **overrides):
+        options = settings.THUMBNAIL_ALIASES[''][alias_name]
+        options.update(overrides)
+        output = self.render_template(src)
+        expected = self.verify_thumbnail(options['size'], options)
+        expected_url = ''.join((settings.MEDIA_URL, expected))
+        self.assertEqual(output, expected_url)
+
+    def test_invalid_alias_name(self):
+        self.assertEqual(
+            self.render_template('{% thumbnail filename "notanalias" %}'),
+            ''
+        )
+
+    def test_correct_alias(self):
+        self.assertCorrectOutput('{% thumbnail filename "small" %}', 'small')
+
+    def test_alias_overrides(self):
+        self.assertCorrectOutput(
+            '{% thumbnail filename "small" upscale %}',
+            'small',
+            upscale=True,
+        )
+        self.assertCorrectOutput(
+            '{% thumbnail filename "small" upscale bw %}',
+            'small',
+            bw=True,
+            upscale=True,
+        )
+


### PR DESCRIPTION
- could extend to allow variables, not just hardcoded  strings as aliases
  - not sure what needs to be done to take alias 'target' into consideration
