### PR TITLE
Fixed handling of unicode file path for get_source_modtime and get_thumbnail_modtime

### DIFF
--- a/easy_thumbnails/files.py
+++ b/easy_thumbnails/files.py
@@ -504,6 +504,8 @@ class Thumbnailer(File):
             return 0
         except NotImplementedError:
             return None
+        except UnicodeEncodeError:
+            return None
 
     def get_thumbnail_modtime(self, thumbnail_name):
         try:
@@ -512,6 +514,8 @@ class Thumbnailer(File):
         except OSError:
             return 0
         except NotImplementedError:
+            return None
+        except UnicodeEncodeError:
             return None
 
     def open(self, mode=None):


### PR DESCRIPTION
When the file path contains unicode caracters an exception is raised because easy_thumbnails fails to get the file's modtime.
