### PR TITLE
Preserve the ICC color profile

### DIFF
--- a/easy_thumbnails/files.py
+++ b/easy_thumbnails/files.py
@@ -301,6 +301,8 @@ class Thumbnailer(File):
         if image is None:
             raise exceptions.InvalidImageFormatError(
                 "The source file does not appear to be an image")
+            
+        icc_profile = image.info.get("icc_profile")
 
         thumbnail_image = engine.process_image(image, thumbnail_options,
                                                self.thumbnail_processors)
@@ -315,7 +317,7 @@ class Thumbnailer(File):
             high_resolution=high_resolution)
 
         img = engine.save_image(
-            thumbnail_image, filename=filename, quality=quality)
+            thumbnail_image, filename=filename, quality=quality, icc_profile=icc_profile)
         data = img.read()
 
         thumbnail = ThumbnailFile(


### PR DESCRIPTION
Some clients of ours complained about thumbnails that have slightly different colors than the original image. The reason for this is that the saved thumbnails do no longer contain the embedded ICC color profile. This commit preserves the ICC profile and adds it again when the thumbnail gets saved.
