### PR TITLE
add error handling for importing six

### DIFF
--- a/easy_thumbnails/utils.py
+++ b/easy_thumbnails/utils.py
@@ -1,7 +1,11 @@
 import inspect
 import math
 import datetime
-import six
+
+try:
+    import six
+except ImportError:
+    from django.utils import six
 
 from django.utils.functional import LazyObject
 


### PR DESCRIPTION
It was introduced in Django 1.4.2; see: https://docs.djangoproject.com/en/1.5/topics/python3/#philosophy
