### PR TITLE
Disable subsampling in JPEG images to improve the quality

### DIFF
--- a/easy_thumbnails/conf.py
+++ b/easy_thumbnails/conf.py
@@ -244,5 +244,14 @@ class Settings(AppSettings):
     Creates a "@2x" version of the thumbnails that can be used by a javascript
     layer to display higher quality thumbnails for high DPI displays.
     """
+    
+    THUMBNAIL_JPEG_SUBSAMPLING = True
+    """
+    Enables subsampling for JPEG images.
+
+    Set this to False if you want to disable subsampling in JPEG images.
+    This will improve the output quality but will lead to an increased file 
+    size.
+    """
 
 settings = Settings()

--- a/easy_thumbnails/engine.py
+++ b/easy_thumbnails/engine.py
@@ -47,12 +47,14 @@ def save_image(image, destination=None, filename=None, **options):
     format = Image.EXTENSION.get(os.path.splitext(filename)[1], 'JPEG')
     if format == 'JPEG':
         options.setdefault('quality', 85)
+        if not settings.THUMBNAIL_JPEG_SUBSAMPLING:
+            options.setdefault('subsampling', 0)
         try:
-            image.save(destination, format=format, optimize=1, subsampling=0, **options)
+            image.save(destination, format=format, optimize=1, **options)
         except IOError:
             # Try again, without optimization (PIL can't optimize an image
             # larger than ImageFile.MAXBLOCK, which is 64k by default)
-            image.save(destination, format=format, subsampling=0, **options)
+            image.save(destination, format=format, **options)
     else:
         image.save(destination, format=format, **options)
     if hasattr(destination, 'seek'):


### PR DESCRIPTION
By adding subsampling=0 to the PIL save method, the JPEG image quality can be improved drastically.

Here is an example (watch the red text in the image):

Original image: http://s12.postimg.org/5xajlw9al/cover_original.jpg
Image with subsampling: http://s11.postimg.org/wmi05mqw3/cover_with_subsampling.jpg
Image without subsampling: http://s12.postimg.org/saia8pa8d/cover_without_subsampling.jpg

It would be great if you could merge this pull request into the master. Thanks!
