### PR TITLE
optionally hide options in generated file name

### DIFF
--- a/easy_thumbnails/files.py
+++ b/easy_thumbnails/files.py
@@ -342,7 +342,7 @@ class Thumbnailer(File):
         initial_opts = ['%sx%s' % size, 'q%s' % quality]
 
         opts = ['%s' % (v is not True and '%s-%s' % (k, v) or k)
-                for k, v in sorted(thumbnail_options.items()) if v]
+                for k, v in sorted(thumbnail_options.items()) if v and not k.startswith('_')]
 
         all_opts = '_'.join(initial_opts + opts)
 


### PR DESCRIPTION
This is useful if one wants to hide from the generated thumb file name various informations (say a watermark file name), or having options that do not necessarily needs a thumb regeneration if they are changed.
I saw #204 and #239 , this is a patch regarding a similar problem but attaching the problem from a different angle.
