### PR TITLE
Replaced u' string literal prefixes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@
 import os
 import sys
 from django.conf import settings
+import six.u
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -41,8 +42,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'easy-thumbnails'
-copyright = u'2009, Chris Beaven'
+project = six.u('easy-thumbnails')
+copyright = six.u('2009, Chris Beaven')
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -177,8 +178,8 @@ htmlhelp_basename = 'easy-thumbnailsdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-    ('index', 'easy-thumbnails.tex', u'easy-thumbnails Documentation',
-     u'Chris Beaven', 'manual'),
+    ('index', 'easy-thumbnails.tex', 'easy-thumbnails Documentation',
+     'Chris Beaven', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/easy_thumbnails/migrations/0016_auto__add_thumbnaildimensions.py
+++ b/easy_thumbnails/migrations/0016_auto__add_thumbnaildimensions.py
@@ -9,41 +9,41 @@ class Migration(SchemaMigration):
 
     def forwards(self, orm):
         # Adding model 'ThumbnailDimensions'
-        db.create_table(u'easy_thumbnails_thumbnaildimensions', (
-            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+        db.create_table('easy_thumbnails_thumbnaildimensions', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
             ('thumbnail', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['easy_thumbnails.Thumbnail'], unique=True)),
             ('width', self.gf('django.db.models.fields.PositiveIntegerField')(null=True)),
             ('height', self.gf('django.db.models.fields.PositiveIntegerField')(null=True)),
         ))
-        db.send_create_signal(u'easy_thumbnails', ['ThumbnailDimensions'])
+        db.send_create_signal('easy_thumbnails', ['ThumbnailDimensions'])
 
 
     def backwards(self, orm):
         # Deleting model 'ThumbnailDimensions'
-        db.delete_table(u'easy_thumbnails_thumbnaildimensions')
+        db.delete_table('easy_thumbnails_thumbnaildimensions')
 
 
     models = {
-        u'easy_thumbnails.source': {
+        'easy_thumbnails.source': {
             'Meta': {'unique_together': "(('storage_hash', 'name'),)", 'object_name': 'Source'},
-            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'modified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
             'storage_hash': ('django.db.models.fields.CharField', [], {'max_length': '40', 'db_index': 'True'})
         },
-        u'easy_thumbnails.thumbnail': {
+        'easy_thumbnails.thumbnail': {
             'Meta': {'unique_together': "(('storage_hash', 'name', 'source'),)", 'object_name': 'Thumbnail'},
-            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'modified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
-            'source': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'thumbnails'", 'to': u"orm['easy_thumbnails.Source']"}),
+            'source': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'thumbnails'", 'to': "orm['easy_thumbnails.Source']"}),
             'storage_hash': ('django.db.models.fields.CharField', [], {'max_length': '40', 'db_index': 'True'})
         },
-        u'easy_thumbnails.thumbnaildimensions': {
+        'easy_thumbnails.thumbnaildimensions': {
             'Meta': {'object_name': 'ThumbnailDimensions'},
             'height': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True'}),
-            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'thumbnail': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['easy_thumbnails.Thumbnail']", 'unique': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'thumbnail': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['easy_thumbnails.Thumbnail']", 'unique': 'True'}),
             'width': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True'})
         }
     }


### PR DESCRIPTION
Replaced u' string literal prefixes with six.u() when necessary or removed them altogether when they are not. Not valid syntax on Python 3.2
