### PR TITLE
Fix failed pip install with python 3.4.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@ Changes
 * New ``subsampling`` option to reduce color subsampling of JPEG images,
   providing sharper color borders for a small increase in file size.
 
-* Reimplementation of the ``thumbnail_cleanup`` command. Thanks Jørgen
+* Reimplementation of the ``thumbnail_cleanup`` command. Thanks Jorgen
   Abrahamsen
 
 * More efficient thumbnail default storage. Thanks Sandip Agarwal.


### PR DESCRIPTION
`pip install` kept failing due to the following error.

```
$ pip3 install easy_thumbnails
Downloading/unpacking easy-thumbnails
  Downloading easy-thumbnails-2.0.1.tar.gz (69kB): 69kB downloaded
  Running setup.py (path:/tmp/pip_build_root/easy-thumbnails/setup.py) egg_info for package easy-thumbnails
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/tmp/pip_build_root/easy-thumbnails/setup.py", line 25, in <module>
        long_description=read_files('README.rst', 'CHANGES.rst'),
      File "/tmp/pip_build_root/easy-thumbnails/setup.py", line 14, in read_files
        output.append(f.read())
      File "/usr/lib/python3.4/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 788: ordinal not in range(128)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/tmp/pip_build_root/easy-thumbnails/setup.py", line 25, in <module>

    long_description=read_files('README.rst', 'CHANGES.rst'),

  File "/tmp/pip_build_root/easy-thumbnails/setup.py", line 14, in read_files

    output.append(f.read())

  File "/usr/lib/python3.4/encodings/ascii.py", line 26, in decode

    return codecs.ascii_decode(input, self.errors)[0]

UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 788: ordinal not in range(128)
```

I guess the actual problem is elsewhere but this works as a temporary fix.
