### PR TITLE
Have thumbnail_cleanup work in Python 2.6 too

### DIFF
--- a/easy_thumbnails/management/commands/thumbnail_cleanup.py
+++ b/easy_thumbnails/management/commands/thumbnail_cleanup.py
@@ -93,11 +93,11 @@ class ThumbnailCollectionCleaner(object):
         Print statistics about the cleanup performed.
         """
         print(
-            "{:-<48}".format(str(datetime.now().strftime('%Y-%m-%d %H:%M '))))
-        print("{:<40} {:>7}".format("Sources checked:", self.sources))
-        print("{:<40} {:>7}".format(
+            "{0:-<48}".format(str(datetime.now().strftime('%Y-%m-%d %H:%M '))))
+        print("{0:<40} {1:>7}".format("Sources checked:", self.sources))
+        print("{0:<40} {1:>7}".format(
             "Source references deleted from DB:", self.source_refs_deleted))
-        print("{:<40} {:>7}".format("Thumbnails deleted from disk:",
+        print("{0:<40} {1:>7}".format("Thumbnails deleted from disk:",
                                     self.thumbnails_deleted))
         print("(Completed in %s seconds)\n" % self.execution_time)
 


### PR DESCRIPTION
thumbnail_cleanup management command does not work with Python 2.6 because str.format() without indices is supported only in Python 2.7. Information: http://stackoverflow.com/a/10054232
