### PR TITLE
Optimize for alternate storage backends

### DIFF
--- a/easy_thumbnails/optimize/post_processor.py
+++ b/easy_thumbnails/optimize/post_processor.py
@@ -66,6 +66,7 @@ def optimize_thumbnail(thumbnail):
             else:
                 logger.info('{0} returned nothing'.format(optimize_command))
             with open(temp_file.name, 'rb') as f:
+                thumbnail.file = ContentFile(f.read())
                 try:
                     storage.delete(thumbnail.path)
                     storage.save(thumbnail.path, thumbnail)


### PR DESCRIPTION
At the digital agency I work for we use Amazon's S3 for our image storage in production. We found your optimization post-processor and it worked well in development. However, when we went live we noticed the images were no longer being optimised.

The Django package we use is called django-storages: http://django-storages.readthedocs.org/en/latest/index.html

After digging into the `post_processor.py` I found that `thumbnail.path` is not set for cloud-based storage providers and raises a `NotImplementedError`. In this case I detect the file-type from the `url` attribute and save the file referenced by the `name` attribute.

I confirm this is working with S3 but it should be generic enough to work with most other storage backends.
