### PR TITLE
Fix: utils.exif_orientation can raise OverflowError

### DIFF
--- a/easy_thumbnails/utils.py
+++ b/easy_thumbnails/utils.py
@@ -104,7 +104,7 @@ def exif_orientation(im):
     """
     try:
         exif = im._getexif()
-    except (AttributeError, IndexError, KeyError, IOError):
+    except (AttributeError, IndexError, KeyError, IOError, OverflowError):
         exif = None
     if exif:
         orientation = exif.get(0x0112)


### PR DESCRIPTION
In a similar vein to #133, I recently encountered some user-uploaded photos with [corrupt?] EXIF data that caused an OverflowError, which was not caught by easy-thumbnails. This is a straightforward fix.

Example image (large): http://s3.get-to-know.org/contest/entries/2014/2/104447247-491367.jpg

Partial stack trace:

``` python
  File "venv/local/lib/python2.7/site-packages/easy_thumbnails/engine.py", line 85, in generate_source_image
    image = generator(source, **processor_options)

  File "venv/local/lib/python2.7/site-packages/easy_thumbnails/source_generators.py", line 40, in pil_image
    image = utils.exif_orientation(image)

  File "venv/local/lib/python2.7/site-packages/easy_thumbnails/utils.py", line 122, in exif_orientation
    exif = im._getexif()

  File "venv/local/lib/python2.7/site-packages/PIL/JpegImagePlugin.py", line 366, in _getexif
    return _getexif(self)

  File "venv/local/lib/python2.7/site-packages/PIL/JpegImagePlugin.py", line 390, in _getexif
    info.load(file)

  File "venv/local/lib/python2.7/site-packages/PIL/TiffImagePlugin.py", line 444, in load
    fp.seek(i32(ifd, 8))

OverflowError: cannot fit 'long' into an index-sized integer
```

A number of related warnings on stdout:

``` python
venv/local/lib/python2.7/site-packages/PIL/TiffImagePlugin.py:451: UserWarning: Possibly corrupt EXIF data.  Expecting to read 19660800 bytes but only got 0. Skipping tag 0
venv/local/lib/python2.7/site-packages/PIL/TiffImagePlugin.py:451: UserWarning: Possibly corrupt EXIF data.  Expecting to read 65536 bytes but only got 0. Skipping tag 3
venv/local/lib/python2.7/site-packages/PIL/TiffImagePlugin.py:451: UserWarning: Possibly corrupt EXIF data.  Expecting to read 524288 bytes but only got 0. Skipping tag 5
venv/local/lib/python2.7/site-packages/PIL/TiffImagePlugin.py:451: UserWarning: Possibly corrupt EXIF data.  Expecting to read 1048576 bytes but only got 0. Skipping tag 5
venv/local/lib/python2.7/site-packages/PIL/TiffImagePlugin.py:451: UserWarning: Possibly corrupt EXIF data.  Expecting to read 131072 bytes but only got 0. Skipping tag 3
venv/local/lib/python2.7/site-packages/PIL/TiffImagePlugin.py:451: UserWarning: Possibly corrupt EXIF data.  Expecting to read 12582912 bytes but only got 0. Skipping tag 2
```
