### PR TITLE
Pull request to SmileyChris/master from fredpalmer/bug/django-1.7rc3-compat

### DIFF
--- a/easy_thumbnails/migrations/0001_initial.py
+++ b/easy_thumbnails/migrations/0001_initial.py
@@ -1,4 +1,6 @@
-# encoding: utf8
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 from django.db import models, migrations
 import django.utils.timezone
 
@@ -12,29 +14,35 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Source',
             fields=[
-                (u'id', models.AutoField(verbose_name=u'ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('storage_hash', models.CharField(max_length=40, db_index=True)),
                 ('name', models.CharField(max_length=255, db_index=True)),
                 ('modified', models.DateTimeField(default=django.utils.timezone.now)),
             ],
             options={
-                u'unique_together': set([('storage_hash', 'name')]),
-                u'abstract': False,
+                'abstract': False,
             },
             bases=(models.Model,),
         ),
         migrations.CreateModel(
             name='Thumbnail',
             fields=[
-                (u'id', models.AutoField(verbose_name=u'ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('storage_hash', models.CharField(max_length=40, db_index=True)),
                 ('name', models.CharField(max_length=255, db_index=True)),
                 ('modified', models.DateTimeField(default=django.utils.timezone.now)),
-                ('source', models.ForeignKey(to='easy_thumbnails.Source', to_field=u'id')),
+                ('source', models.ForeignKey(related_name=b'thumbnails', to='easy_thumbnails.Source')),
             ],
             options={
-                u'unique_together': set([('storage_hash', 'name', 'source')]),
             },
             bases=(models.Model,),
+        ),
+        migrations.AlterUniqueTogether(
+            name='thumbnail',
+            unique_together=set([('storage_hash', 'name', 'source')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='source',
+            unique_together=set([('storage_hash', 'name')]),
         ),
     ]

--- a/easy_thumbnails/migrations/0002_thumbnaildimensions.py
+++ b/easy_thumbnails/migrations/0002_thumbnaildimensions.py
@@ -1,4 +1,6 @@
-# encoding: utf8
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 from django.db import models, migrations
 
 
@@ -12,10 +14,10 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='ThumbnailDimensions',
             fields=[
-                (u'id', models.AutoField(verbose_name=u'ID', serialize=False, auto_created=True, primary_key=True)),
-                ('thumbnail', models.OneToOneField(to='easy_thumbnails.Thumbnail', to_field=u'id')),
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('width', models.PositiveIntegerField(null=True)),
                 ('height', models.PositiveIntegerField(null=True)),
+                ('thumbnail', models.OneToOneField(related_name=b'dimensions', to='easy_thumbnails.Thumbnail')),
             ],
             options={
             },


### PR DESCRIPTION
Please pull these commits into SmileyChris/master.  Here is the latest commit message:

_"Running makemigrations with any Django 1.7rc3 project and easy_thumbnails would have a false positive that there were model changes not applied the 0001 and 0002 migrations for this project.  I have created fresh migrations from the latest Django and have separated them into their semantic equivalent 0001 and 0002 migrations.  This should allow a more painless upgrade for existing users of Django 1.7 and also keep new users from seeing the current false positive issue"_
