### PR TITLE
print_stats() in management command obey to verbosity

### DIFF
--- a/easy_thumbnails/management/commands/thumbnail_cleanup.py
+++ b/easy_thumbnails/management/commands/thumbnail_cleanup.py
@@ -150,4 +150,5 @@ class Command(BaseCommand):
             verbosity=int(options.get('verbosity', 1)),
             last_n_days=int(options.get('last_n_days', 0)),
             cleanup_path=options.get('cleanup_path'))
-        tcc.print_stats()
+        if int(options.get('verbosity', 1) > 0:
+            tcc.print_stats()


### PR DESCRIPTION
I am using the management command in cron jobs, and I prefere to mute it, so I have added a if to make it obey to the verbosity option. I hope you'll accept this pull request and that it will help many other user. Thank you.
