### PR TITLE
Added optional generate param to generate_all_aliases

### DIFF
--- a/easy_thumbnails/files.py
+++ b/easy_thumbnails/files.py
@@ -500,6 +500,9 @@ class Thumbnailer(File):
         Force the generation behaviour by setting the ``generate`` param to
         either ``True`` or ``False`` as required.
 
+        Force re-generation behaviour (even if thumbnail already exists) by setting
+        the force param to either True or False as required.
+
         The new thumbnail image is generated using the ``thumbnail_options``
         dictionary. If the ``save`` argument is ``True`` (default), the
         generated thumbnail will be saved too.


### PR DESCRIPTION
Hey,
I found it useful to be able to pass in the generate=True parameter to generate_all_aliases, e.g in some cases where I use this with a signal handler / async. task. Pretty straight forward and seems useful.

On a side note, I couldn't figure out a way to have automatic re-generation of thumbnails when I change the original image (e.g when original image ImageField is already populated and had thumbnails generated, if i change it by uploading new file, I cannot seem to get easy-thumbnails to re-generate thumbnails automatically based on the fact file is modified, when trying to use the saved_file receiver/signals as suggested in documentation).
