### PR TITLE
Django 1.8 warnings fix

### DIFF
--- a/easy_thumbnails/models.py
+++ b/easy_thumbnails/models.py
@@ -61,7 +61,8 @@ class File(models.Model):
 
 
 class Source(File):
-    pass
+    class Meta(File.Meta):
+        app_label = 'easy_thumbnails'
 
 
 class Thumbnail(File):
@@ -69,6 +70,7 @@ class Thumbnail(File):
 
     class Meta:
         unique_together = (('storage_hash', 'name', 'source'),)
+        app_label = 'easy_thumbnails'
 
 
 class ThumbnailDimensions(models.Model):
@@ -82,6 +84,9 @@ class ThumbnailDimensions(models.Model):
     @property
     def size(self):
         return self.width, self.height
+
+    class Meta:
+        app_label = 'easy_thumbnails'
 
 
 models.signals.pre_save.connect(signal_handlers.find_uncommitted_filefields)


### PR DESCRIPTION
Fixed warnings in development Django version:

```
/Users/smee/PycharmProjects/shantishop/system/venv/lib/python2.7/site-packages/easy_thumbnails/models.py:63: RemovedInDjango19Warning: Model class easy_thumbnails.models.Source doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class Source(File):

WARNING  [2014-12-13 00:45:27,366] /Users/smee/PycharmProjects/shantishop/system/venv/lib/python2.7/site-packages/easy_thumbnails/models.py:63: RemovedInDjango19Warning: Model class easy_thumbnails.models.Source doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class Source(File):

/Users/smee/PycharmProjects/shantishop/system/venv/lib/python2.7/site-packages/easy_thumbnails/models.py:67: RemovedInDjango19Warning: Model class easy_thumbnails.models.Thumbnail doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class Thumbnail(File):

WARNING  [2014-12-13 00:45:27,368] /Users/smee/PycharmProjects/shantishop/system/venv/lib/python2.7/site-packages/easy_thumbnails/models.py:67: RemovedInDjango19Warning: Model class easy_thumbnails.models.Thumbnail doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class Thumbnail(File):

/Users/smee/PycharmProjects/shantishop/system/venv/lib/python2.7/site-packages/easy_thumbnails/models.py:74: RemovedInDjango19Warning: Model class easy_thumbnails.models.ThumbnailDimensions doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class ThumbnailDimensions(models.Model):

WARNING  [2014-12-13 00:45:27,369] /Users/smee/PycharmProjects/shantishop/system/venv/lib/python2.7/site-packages/easy_thumbnails/models.py:74: RemovedInDjango19Warning: Model class easy_thumbnails.models.ThumbnailDimensions doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class ThumbnailDimensions(models.Model):
```