### PR TITLE
Add alias namer

### DIFF
--- a/easy_thumbnails/conf.py
+++ b/easy_thumbnails/conf.py
@@ -196,7 +196,7 @@ class Settings(AppSettings):
     """
     The function used to generate the filename for thumbnail images.
 
-    Three namers are included in easy_thumbnails:
+    Four namers are included in easy_thumbnails:
 
     ``easy_thumbnails.namers.default``
         Descriptive filename containing the source and options like
@@ -204,6 +204,9 @@ class Settings(AppSettings):
 
     ``easy_thumbnails.namers.hashed``
         Short hashed filename like ``1xedFtqllFo9.jpg``.
+
+    ``easy_thumbnails.namers.alias``
+        Filename based on ``THUMBNAIL_ALIASES`` dictionary key like ``source.jpg.medium_large.jpg``.
 
     ``easy_thumbnails.namers.source_hashed``
         Filename with source hashed, size, then options hashed like

--- a/easy_thumbnails/files.py
+++ b/easy_thumbnails/files.py
@@ -88,7 +88,8 @@ def generate_all_aliases(fieldfile, include_global):
     all_options = aliases.all(fieldfile, include_global=include_global)
     if all_options:
         thumbnailer = get_thumbnailer(fieldfile)
-        for options in all_options.values():
+        for key, options in six.iteritems(all_options):
+            options['ALIAS'] = key
             thumbnailer.get_thumbnail(options)
 
 

--- a/easy_thumbnails/namers.py
+++ b/easy_thumbnails/namers.py
@@ -21,6 +21,16 @@ def default(thumbnailer, prepared_options, source_filename,
     return '.'.join(filename_parts)
 
 
+def alias(thumbnailer, thumbnail_options, source_filename,
+            thumbnail_extension, **kwargs):
+    """
+    Generate filename based on thumbnail alias name (option ``THUMBNAIL_ALIASES``).
+
+    For example: ``source.jpg.medium_large.jpg``
+    """
+    return '.'.join([source_filename, thumbnail_options.get('ALIAS', ''), thumbnail_extension])
+
+
 def hashed(source_filename, prepared_options, thumbnail_extension, **kwargs):
     """
     Generate a short hashed thumbnail filename.

--- a/easy_thumbnails/tests/test_files.py
+++ b/easy_thumbnails/tests/test_files.py
@@ -314,15 +314,6 @@ class FilesTest(test.BaseTest):
             self.thumbnailer.get_thumbnail_name(opts),
             'test.jpg.50x50_q85_crop-smart_target-10,10_upscale.jpg')
 
-    def test_get_thumbnail_name_alias(self):
-        settings.THUMBNAIL_NAMER = 'easy_thumbnails.namers.alias'
-        opts = {
-            'size': (50, 50), 'crop': 'smart', 'upscale': True,
-            'target': (10, 10), 'ALIAS': 'medium_large'}
-        self.assertEqual(
-            self.thumbnailer.get_thumbnail_name(opts),
-            'test.jpg.medium_large.jpg')
-
     def test_default_options_setting(self):
         settings.THUMBNAIL_DEFAULT_OPTIONS = {'crop': True}
         opts = {'size': (50, 50)}

--- a/easy_thumbnails/tests/test_files.py
+++ b/easy_thumbnails/tests/test_files.py
@@ -314,6 +314,15 @@ class FilesTest(test.BaseTest):
             self.thumbnailer.get_thumbnail_name(opts),
             'test.jpg.50x50_q85_crop-smart_target-10,10_upscale.jpg')
 
+    def test_get_thumbnail_name_alias(self):
+        settings.THUMBNAIL_NAMER = 'easy_thumbnails.namers.alias'
+        opts = {
+            'size': (50, 50), 'crop': 'smart', 'upscale': True,
+            'target': (10, 10), 'ALIAS': 'medium_large'}
+        self.assertEqual(
+            self.thumbnailer.get_thumbnail_name(opts),
+            'test.jpg.medium_large.jpg')
+
     def test_default_options_setting(self):
         settings.THUMBNAIL_DEFAULT_OPTIONS = {'crop': True}
         opts = {'size': (50, 50)}

--- a/easy_thumbnails/tests/test_namers.py
+++ b/easy_thumbnails/tests/test_namers.py
@@ -52,6 +52,19 @@ class Hashed(TestCase):
         self.assertEqual(filename, '6qW1buHgLaZ9.jpg')
 
 
+class Alias(TestCase):
+
+    def test_basic(self):
+        filename = namers.alias(
+            thumbnailer=FakeThumbnailer(),
+            prepared_options=['100x100', 'q80', 'crop', 'upscale'],
+            thumbnail_options={'size': (100, 100), 'ALIAS': 'medium_large'},
+            source_filename='source.jpg',
+            thumbnail_extension='jpg',
+        )
+        self.assertEqual(filename, 'source.jpg.medium_large.jpg')
+
+
 class SourceHashed(TestCase):
 
     def test_basic(self):


### PR DESCRIPTION
Addressing #375 - new `easy_thumbnails.namers.alias` namer added. Documentation updated, test working.

Apologies for the new pull request (old one was accidentally closed).