### PR TITLE
template filter datauri

### DIFF
--- a/easy_thumbnails/templatetags/thumbnail.py
+++ b/easy_thumbnails/templatetags/thumbnail.py
@@ -321,4 +321,5 @@ def data_uri(thumbnail):
     finally:
         thumbnail.close()
     mime_type = mimetypes.guess_type(str(thumbnail.file))[0] or 'application/octet-stream'
-    return 'data:{0};base64,{1}'.format(mime_type, b64encode(data))
+    data = b64encode(data).decode('utf-8')
+    return 'data:{0};base64,{1}'.format(mime_type, data)

--- a/easy_thumbnails/templatetags/thumbnail.py
+++ b/easy_thumbnails/templatetags/thumbnail.py
@@ -1,4 +1,6 @@
 import re
+from base64 import b64encode
+import mimetypes
 from django.utils import six
 
 from django.template import (
@@ -299,3 +301,24 @@ def thumbnail_url(source, alias):
     return thumb.url
 
 
+@register.filter
+def data_uri(thumbnail):
+    """
+    This filter will return the base64 encoded data URI for a given thumbnail object.
+
+    Example usage::
+
+        {% thumbnail sample_image 25x25 crop as thumb %}
+        <img src="{{ thumb|data_uri }}">
+
+    will for instance be rendered as:
+
+        <img src="data:image/png;base64,iVBORw0KGgo...">
+    """
+    try:
+        thumbnail.open('rb')
+        data = thumbnail.read()
+    finally:
+        thumbnail.close()
+    mime_type = mimetypes.guess_type(str(thumbnail.file))[0] or 'application/octet-stream'
+    return 'data:{0};base64,{1}'.format(mime_type, b64encode(data))

--- a/easy_thumbnails/templatetags/thumbnail.py
+++ b/easy_thumbnails/templatetags/thumbnail.py
@@ -128,6 +128,7 @@ class ThumbnailNode(Node):
         return ''
 
 
+@register.tag
 def thumbnail(parser, token):
     """
     Creates a thumbnail of an ImageField.
@@ -228,6 +229,7 @@ def thumbnail(parser, token):
     return ThumbnailNode(source_var, opts=opts, context_name=context_name)
 
 
+@register.filter
 def thumbnailer(obj, relative_name=None):
     """
     Creates a thumbnailer from an object (usually a ``FileField``).
@@ -251,6 +253,7 @@ def thumbnailer(obj, relative_name=None):
     return get_thumbnailer(obj, relative_name=relative_name)
 
 
+@register.filter
 def thumbnailer_passive(obj):
     """
     Creates a thumbnailer from an object (usually a ``FileFile``) that won't
@@ -277,6 +280,7 @@ def thumbnailer_passive(obj):
     return thumbnailer
 
 
+@register.filter
 def thumbnail_url(source, alias):
     """
     Return the thumbnail url for a source file using an aliased set of
@@ -295,7 +299,3 @@ def thumbnail_url(source, alias):
     return thumb.url
 
 
-register.tag(thumbnail)
-register.filter(thumbnailer)
-register.filter(thumbnailer_passive)
-register.filter(thumbnail_url)

--- a/easy_thumbnails/tests/test_templatetags.py
+++ b/easy_thumbnails/tests/test_templatetags.py
@@ -340,6 +340,6 @@ class ThumbnailerDataUriTest(ThumbnailerBase):
             '{% thumbnail source 25x25 as thumb %}'
             '{{ thumb|data_uri }}'
         )
-        output = self.render_template(src)
-        startswith = 'data:application/octet-stream;base64,b&#39;/9j/4AAQSkZJRgABAQAAAQABAAD'
-        self.assertTrue(output.startswith(startswith))
+        output = self.render_template(src)[:64]
+        startswith = 'data:application/octet-stream;base64,/9j/4AAQSkZJRgABAQAAAQABAAD'
+        self.assertEqual(output, startswith)

--- a/easy_thumbnails/tests/test_templatetags.py
+++ b/easy_thumbnails/tests/test_templatetags.py
@@ -331,3 +331,15 @@ class ThumbnailTagAliasTest(ThumbnailerBase):
             bw=True,
             upscale=True,
         )
+
+
+class ThumbnailerDataUriTest(ThumbnailerBase):
+
+    def test_data_uri(self):
+        src = (
+            '{% thumbnail source 25x25 as thumb %}'
+            '{{ thumb|data_uri }}'
+        )
+        output = self.render_template(src)
+        startswith = 'data:application/octet-stream;base64,b&#39;/9j/4AAQSkZJRgABAQAAAQABAAD'
+        self.assertTrue(output.startswith(startswith))


### PR DESCRIPTION
This filter will return the base64 encoded data URI for a given thumbnail object.

Very handy for small images to prevent an additional HTTP request.

Also useful when rendering HTML emails since most mail clients do not preload images referring external URL's. In order to make them immediately visible, they must be part of the payload. This filter can be used for it.

Example usage::
```
{% thumbnail sample_image 25x25 crop as thumb %}
<img src="{{ thumb|data_uri }}">
```
will for instance be rendered as:
```
<img src="data:image/png;base64,iVBORw0KGgo...">
```
