### PR TITLE
Do not hide exceptions for template tags

### DIFF
--- a/easy_thumbnails/templatetags/thumbnail.py
+++ b/easy_thumbnails/templatetags/thumbnail.py
@@ -295,10 +295,7 @@ def thumbnail_url(source, alias):
 
         <img src="{{ person.photo|thumbnail_url:'small' }}" alt="">
     """
-    try:
-        thumb = get_thumbnailer(source)[alias]
-    except Exception:
-        return ''
+    thumb = get_thumbnailer(source)[alias]
     return thumb.url
 
 


### PR DESCRIPTION
I think it is a bad to catch all possible errors. 

>  "using a bare except: is almost never a good idea" 
https://docs.python.org/2/howto/doanddont.html#except

Also this exception hides this error inside:
```
File "PIL/Image.py", line 375, in _getdecoder
    raise IOError("decoder %s not available" % decoder_name)
IOError: decoder jpeg not available
```

It comes out that it really hard to know why template tag is not working and fix the issue :) Thank you! 