### PR TITLE
Fix documentation example to use src attribute

### DIFF
--- a/easy_thumbnails/templatetags/thumbnail.py
+++ b/easy_thumbnails/templatetags/thumbnail.py
@@ -172,7 +172,7 @@ def thumbnail(parser, token):
     use the variable like a standard ``ImageFieldFile`` object::
 
         {% thumbnail obj.picture 200x200 upscale as thumb %}
-        <img href="{{ thumb.url }}"
+        <img src="{{ thumb.url }}"
              width="{{ thumb.width }}"
              height="{{ thumb.height }}" />
 


### PR DESCRIPTION
In the pydoc example, instead of the incorrect href attribute, the img tag should use the src attribute.

Many thanks for an awesome library, thought I'd contribute back! :smile: 