### PR TITLE
Fix for blank image url in thumbnail template tag

### DIFF
--- a/easy_thumbnails/templatetags/thumbnail.py
+++ b/easy_thumbnails/templatetags/thumbnail.py
@@ -172,7 +172,7 @@ def thumbnail(parser, token):
     use the variable like a standard ``ImageFieldFile`` object::
 
         {% thumbnail obj.picture 200x200 upscale as thumb %}
-        <img src="{{ thumb.url }}"
+        <img src="{{ thumb }}"
              width="{{ thumb.width }}"
              height="{{ thumb.height }}" />
 


### PR DESCRIPTION
This patch fixes my issue, but I don't think it's an ImageFieldFile either. It seems like the templatetag will create a ThumbnailFile object - exactly the same as when calling the tag directly
