### PR TITLE
Use get_modified_time api for storage introduced in Django 1.10

### DIFF
--- a/easy_thumbnails/tests/settings.py
+++ b/easy_thumbnails/tests/settings.py
@@ -14,6 +14,11 @@ DATABASES = {
     }
 }
 
+TEMPLATES = [{
+    'BACKEND': 'django.template.backends.django.DjangoTemplates',
+}]
+
+
 INSTALLED_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.sites',

--- a/easy_thumbnails/utils.py
+++ b/easy_thumbnails/utils.py
@@ -1,6 +1,8 @@
 import hashlib
 import inspect
 import math
+
+import django
 from django.utils import six
 
 from django.utils.functional import LazyObject
@@ -143,7 +145,10 @@ def get_modified_time(storage, name):
     datetime.
     """
     try:
-        modified_time = storage.modified_time(name)
+        if django.VERSION >= (1,10):
+            return storage.get_modified_time(name)
+        else:
+            modified_time = storage.modified_time(name)
     except OSError:
         return 0
     except NotImplementedError:


### PR DESCRIPTION
The old API is being dropped in Django 2.