### PR TITLE
Setting to use Django's cache

### DIFF
--- a/easy_thumbnails/conf.py
+++ b/easy_thumbnails/conf.py
@@ -325,6 +325,14 @@ class Settings(AppSettings):
     still works as a fall back.
     """
 
+    THUMBNAIL_CACHE = None
+    """
+    Use Django's caching system to cache sources and thumbnails
+
+    Setting this to ``None`` will disable caching.  To enable it, set
+    this to the name of the Django cache you would like to use.
+    """
+
     THUMBNAIL_WIDGET_OPTIONS = {'size': (80, 80)}
     """
     Default options for the

--- a/easy_thumbnails/models.py
+++ b/easy_thumbnails/models.py
@@ -75,6 +75,7 @@ class ThumbnailManager(FileManager):
         return self
 
     def _get_cache_key(self, kwargs):
+        kwargs['source_id'] = kwargs['source'].pk
         return 'et:thumbnail:{storage_hash}:{name}:{source_id}'.format(**kwargs)
 
 


### PR DESCRIPTION
This is to address #342, caching source and thumbnail models in Django's cache in order to avoid excessive SQL queries.