### PR TITLE
Fix management command handling for Django 1.10

### DIFF
--- a/easy_thumbnails/management/commands/thumbnail_cleanup.py
+++ b/easy_thumbnails/management/commands/thumbnail_cleanup.py
@@ -121,7 +121,7 @@ def queryset_iterator(queryset, chunksize=1000):
 class Command(BaseCommand):
     help = """ Deletes thumbnails that no longer have an original file. """
 
-    option_list = BaseCommand.option_list + (
+    option_list = getattr(BaseCommand, "option_list", ()) + (
         make_option(
             '--dry-run',
             action='store_true',


### PR DESCRIPTION
BaseCommand.option_list was removed in Django 1.10