### PR TITLE
Fix for type mismatch between THUMBNAIL_PROCESSORS and THUMBNAIL_SOURCE_GENERATORS

### DIFF
--- a/easy_thumbnails/utils.py
+++ b/easy_thumbnails/utils.py
@@ -49,8 +49,8 @@ def valid_processor_options(processors=None):
     if processors is None:
         processors = [
             dynamic_import(p) for p in
-            settings.THUMBNAIL_PROCESSORS +
-            settings.THUMBNAIL_SOURCE_GENERATORS]
+            tuple(settings.THUMBNAIL_PROCESSORS) +
+            tuple(settings.THUMBNAIL_SOURCE_GENERATORS)]
     valid_options = set(['size', 'quality', 'subsampling'])
     for processor in processors:
         args = inspect.getargspec(processor)[0]


### PR DESCRIPTION
This one is rather silly. I was using the following in my project's settings.py: 

```python
THUMBNAIL_PROCESSORS = [
	'easy_thumbnails.processors.colorspace',
	'easy_thumbnails.processors.autocrop',
	'filer.thumbnail_processors.scale_and_crop_with_subject_location',
	'easy_thumbnails.processors.filters',
]
```

But that caused this error:

      File "/Users/rspeed/Projects/UVFlowers/lib/python3.5/site-packages/easy_thumbnails/utils.py", line 53, in valid_processor_options
        settings.THUMBNAIL_SOURCE_GENERATORS]
    TypeError: can only concatenate list (not "tuple") to list

This is due to `easy-thumbnails` using the + operator to combine the two settings. Since Python won't perform an operation where the type of the output isn't obvious, it raises that exception.

This PR implements a solution which minimizes any other impact. The only change is that each of the two variables are cast to tuples prior to being joined.