### PR TITLE
Use get_modified_time api if available

### DIFF
--- a/easy_thumbnails/utils.py
+++ b/easy_thumbnails/utils.py
@@ -143,7 +143,11 @@ def get_modified_time(storage, name):
     datetime.
     """
     try:
-        modified_time = storage.modified_time(name)
+        try:
+            return storage.get_modified_time(name)
+        except AttributeError:
+            # Fall back to pre-Django 1.10 API
+            modified_time = storage.modified_time(name)
     except OSError:
         return 0
     except NotImplementedError:


### PR DESCRIPTION
Introduced in Django 1.10. Django 2.0 (now Git master) will drop the old API entirely.