### PR TITLE
Changed type values to callables

### DIFF
--- a/easy_thumbnails/management/commands/thumbnail_cleanup.py
+++ b/easy_thumbnails/management/commands/thumbnail_cleanup.py
@@ -134,13 +134,13 @@ class Command(BaseCommand):
             action='store',
             dest='last_n_days',
             default=0,
-            type='int',
+            type=int,
             help='The number of days back in time to clean thumbnails for.'),
         make_option(
             '--path',
             action='store',
             dest='cleanup_path',
-            type='string',
+            type=str,
             help='Specify a path to clean up.'),
     )
 
@@ -156,13 +156,13 @@ class Command(BaseCommand):
             action='store',
             dest='last_n_days',
             default=0,
-            type='int',
+            type=int,
             help='The number of days back in time to clean thumbnails for.')
         parser.add_argument(
             '--path',
             action='store',
             dest='cleanup_path',
-            type='string',
+            type=str,
             help='Specify a path to clean up.')
 
     def handle(self, *args, **options):


### PR DESCRIPTION
The ArgumentParser requires a callable as value for type when building
an argument. Therefore I have changed the 'int' and 'string' values to
int and str respectively. This fixes a parsing error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/smileychris/easy-thumbnails/445)
<!-- Reviewable:end -->
