### PR TITLE
Fix version check in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'django>=1.4.2',
-        'pillow<4' if sys.version < (2, 7) else 'pillow',
+        'pillow<4' if sys.version_info < (2, 7) else 'pillow',
     ],
     cmdclass={'test': DjangoTests},
     classifiers=[


### PR DESCRIPTION
The tests are failing because on Python3 type comparison became stricter. ``sys.version`` is a string, ``sys.version_info`` is a tuple.