### PR TITLE
Fix type argument in parser.add_argument for django > 1.8

### DIFF
--- a/easy_thumbnails/management/commands/thumbnail_cleanup.py
+++ b/easy_thumbnails/management/commands/thumbnail_cleanup.py
@@ -156,13 +156,13 @@ class Command(BaseCommand):
             action='store',
             dest='last_n_days',
             default=0,
-            type='int',
+            type=int,
             help='The number of days back in time to clean thumbnails for.')
         parser.add_argument(
             '--path',
             action='store',
             dest='cleanup_path',
-            type='string',
+            type=str,
             help='Specify a path to clean up.')
 
     def handle(self, *args, **options):


### PR DESCRIPTION
argparse's type argument expects a callable, not a string representing a type
Fixes `Error parsing command thumbnail_cleanup: 'int' is not callable`
https://docs.python.org/3/library/argparse.html
https://docs.python.org/2/library/argparse.html

@SmileyChris can you merge this please?