### PR TITLE
Add support for Django 1.10 get_modified_time

### DIFF
--- a/easy_thumbnails/utils.py
+++ b/easy_thumbnails/utils.py
@@ -143,7 +143,11 @@ def get_modified_time(storage, name):
     datetime.
     """
     try:
-        modified_time = storage.modified_time(name)
+        try:
+            # Prefer Django 1.10 API and fall back to old one
+            modified_time = storage.get_modified_time(name)
+        except AttributeError:
+            modified_time = storage.modified_time(name)
     except OSError:
         return 0
     except NotImplementedError:


### PR DESCRIPTION
Django 1.10 deprecated `Storage.modified_time` and replaced it with `Storage.get_modified_time` so we should try that first.

Note that the functionality of that will obviate the timezone fixes you do below so we can remove it once you no longer support Django < 1.10.