### PR TITLE
Check for cleared file value

### DIFF
--- a/easy_thumbnails/signal_handlers.py
+++ b/easy_thumbnails/signal_handlers.py
@@ -17,7 +17,8 @@ def find_uncommitted_filefields(sender, instance, **kwargs):
         fields = update_fields.intersection(fields)
     for field in fields:
         if isinstance(field, FileField):
-            if not getattr(instance, field.name)._committed:
+            fieldfile = getattr(instance, field.name)
+            if fieldfile and not fieldfile._committed:
                 uncommitted.append(field.name)
 
 

--- a/easy_thumbnails/tests/test_aliases.py
+++ b/easy_thumbnails/tests/test_aliases.py
@@ -267,6 +267,24 @@ class GenerationTest(GenerationBase):
         files = self.fake_save(profile)
         self.assertEqual(len(files), 0)
 
+    def test_clearable(self):
+        """
+        A ClearablFileInput will set field value to False before pre_save
+        """
+        profile = models.Profile(avatar='avatars/test.jpg')
+        cls = profile.__class__
+
+        profile.avatar = False
+        pre_save.send(sender=cls, instance=profile)
+
+        # Saving will then properly clear
+        profile.avatar = ''
+        post_save.send(sender=cls, instance=profile)
+
+        # FileField is cleared, but not explicitly deleted, file remains
+        files = self.storage.listdir('avatars')[1]
+        self.assertEqual(len(files), 1)
+
     def test_standard_filefield(self):
         profile = models.Profile(avatar='avatars/test.jpg')
         # Attach a File object to the FileField descriptor, emulating an


### PR DESCRIPTION
When clearing a file in the Django Admin by checking the "Clear" checkbox, you get the following error on [this line](https://github.com/SmileyChris/easy-thumbnails/blob/b04b1bf9e6c8561542b0afe129802cd108b6a60c/easy_thumbnails/signal_handlers.py#L20):

`AttributeError: 'bool' object has no attribute '_committed'`

A file field value maybe [`False` when cleared via ClearableFileInput](https://github.com/django/django/blob/5dbf1c4b23cda915369f4895be293369575238d0/django/forms/widgets.py#L416). This PR checks the value before accessing `_committed`.