### PR TITLE
fixed int/string is not a callable in management command

### DIFF
--- a/easy_thumbnails/management/commands/thumbnail_cleanup.py
+++ b/easy_thumbnails/management/commands/thumbnail_cleanup.py
@@ -156,13 +156,13 @@ class Command(BaseCommand):
             action='store',
             dest='last_n_days',
             default=0,
-            type='int',
+            type=int,
             help='The number of days back in time to clean thumbnails for.')
         parser.add_argument(
             '--path',
             action='store',
             dest='cleanup_path',
-            type='string',
+            type=str,
             help='Specify a path to clean up.')
 
     def handle(self, *args, **options):


### PR DESCRIPTION
"type" argument of "add_argument" function was of wrong type (see diff). Management command "thumbnail-cleanup" throws  "int is not a callable" exception when running. At least in current versions of Python 2 and 3.