### PR TITLE
Update utils.py to not give deprecation warnings

### DIFF
--- a/easy_thumbnails/utils.py
+++ b/easy_thumbnails/utils.py
@@ -53,7 +53,7 @@ def valid_processor_options(processors=None):
             tuple(settings.THUMBNAIL_SOURCE_GENERATORS)]
     valid_options = set(['size', 'quality', 'subsampling'])
     for processor in processors:
-        args = inspect.getargspec(processor)[0]
+        args = inspect.signature(processor)[0]
         # Add all arguments apart from the first (the source image).
         valid_options.update(args[1:])
     return list(valid_options)


### PR DESCRIPTION
venv/lib/python3.5/site-packages/easy_thumbnails/utils.py:56: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() instead

change it to inspect.signature() instead of inspect.getargspec() on line 56