### PR TITLE
Replace_alpha and Background options together.

### DIFF
--- a/easy_thumbnails/processors.py
+++ b/easy_thumbnails/processors.py
@@ -315,7 +315,8 @@ def background(im, size, background=None, **kwargs):
         # The image is already equal to (or larger than) the expected size, so
         # there's nothing to do.
         return im
-    im = colorspace(im, replace_alpha=background, **kwargs)
+    kwargs.setdefault('replace_alpha', background) #Avoid duplication in kwargs
+    im = colorspace(im, **kwargs)
     new_im = Image.new('RGB', size, background)
     if new_im.mode != im.mode:
         new_im = new_im.convert(im.mode)


### PR DESCRIPTION
Thanks very much for your work on this app.

I found I got an error when setting thumbnail aliases with both options 'replace_alpha' and 'background' colors, please see below:


Setting both replace_alpha and background thumbnail options could cause errors in the 'background' processor method.
(My use case was 'replace_alpha' in THUMBNAIL_DEFAULT_OPTIONS , but only some of my aliases wanted background padding - other times keeping the original aspect ratio)

With both replace_alpha, and background, there were "multiple values for keyword argument 'replace_alpha'" at the call to colorspace (processors.py, line 318).
It appeared that if replace_alpha occured in **kwargs, then there was an issue as that duplicated the named parameter in this function call.

```
>>> t = get_thumbnailer(mymodel.picture_field)

>>> t.get_thumbnail({'size':(50,50),'replace_alpha':'#FFF','background':'#FFF'})

```
>>> t = get_thumbnailer(mymodel.picture_field)
>>> t.get_thumbnail({'size':(50,50),'replace_alpha':'#FFF','background':'#FFF'})

Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "~\venv\lib\site-packages\easy_thumbnails\files.py", line 517, in get_thumbnail
    silent_template_exception=silent_template_exception)
  File "~\venv\lib\site-packages\easy_thumbnails\files.py", line 391, in generate_thumbnail
    self.thumbnail_processors)
  File "~\venv\lib\site-packages\easy_thumbnails\engine.py", line 40, in process_image
    image = processor(image, **processor_options)
  File "~\venv\lib\site-packages\easy_thumbnails\processors.py", line 318, in background
    im = colorspace(im, replace_alpha=background, **kwargs)
TypeError: colorspace() got multiple values for keyword argument 'replace_alpha'
```

With this change, the alpha can be replaced with one colour, and then a different background padding color applied. (You could use line 318 -> ```kwargs['replace_alpha'] = background``` to have it only listen to the background parameter)