### PR TITLE
Workaround to prevent thumbnail creation for GIFs

### DIFF
--- a/easy_thumbnails/conf.py
+++ b/easy_thumbnails/conf.py
@@ -186,6 +186,11 @@ class Settings(AppSettings):
     Instead of a tuple, you can also set this to ``True`` in order to always
     preserve the original extension.
     """
+    THUMBNAIL_PREVENT_GIF_CONVERT = False
+    """
+    Prevent thumbnail creation for GIFs. Created thumbnails for GIFs have no
+    preserved animations, set to ``True`` if you want to keep them.
+    """
     THUMBNAIL_TRANSPARENCY_EXTENSION = 'png'
     """
     The type of image to save thumbnails with a transparency layer (e.g. GIFs

--- a/easy_thumbnails/templatetags/thumbnail.py
+++ b/easy_thumbnails/templatetags/thumbnail.py
@@ -1,3 +1,4 @@
+import os
 import re
 from base64 import b64encode
 import mimetypes
@@ -113,7 +114,13 @@ class ThumbnailNode(Node):
                 return self.bail_out(context)
 
         try:
-            thumbnail = get_thumbnailer(source).get_thumbnail(opts)
+            bits = False
+            if settings.THUMBNAIL_PREVENT_GIF_CONVERT:
+                bits = os.path.splitext(getattr(source, 'url', source.name))
+            if bits and bits[1] == '.gif':
+                thumbnail = source
+            else:
+                thumbnail = get_thumbnailer(source).get_thumbnail(opts)
         except Exception:
             if raise_errors:
                 raise


### PR DESCRIPTION
Since a solution to preserve animations on GIFs is a bit tricky I made a little workaround to prevent thumbnail creaton for GIFs.

Issues for this problem: #184 and #217