### PR TITLE
Fix compatibility with Django 2.1 (render and renderer)

### DIFF
--- a/easy_thumbnails/widgets.py
+++ b/easy_thumbnails/widgets.py
@@ -54,9 +54,9 @@ class ImageClearableFileInput(ClearableFileInput):
             thumbnailer.thumbnail_storage = value.thumbnail_storage
         return thumbnailer.get_thumbnail(self.thumbnail_options)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         output = super(ImageClearableFileInput, self).render(
-            name, value, attrs)
+            name, value, attrs, renderer)
         if not value or not hasattr(value, 'storage'):
             return output
         thumb = self.get_thumbnail(value)

--- a/easy_thumbnails/widgets.py
+++ b/easy_thumbnails/widgets.py
@@ -56,7 +56,7 @@ class ImageClearableFileInput(ClearableFileInput):
 
     def render(self, name, value, attrs=None, renderer=None):
         output = super(ImageClearableFileInput, self).render(
-            name, value, attrs, renderer)
+            name, value, attrs)
         if not value or not hasattr(value, 'storage'):
             return output
         thumb = self.get_thumbnail(value)


### PR DESCRIPTION
With release notes for django 2.1 and above [Django 2.1 Release Notes](https://docs.djangoproject.com/en/2.1/releases/2.1/#features-removed-in-2-1) signature for method `render` changed with additional `renderer` [Widget.render](https://docs.djangoproject.com/en/2.1/ref/forms/widgets/#django.forms.Widget.render)