### PR TITLE
Updating image entropy implementations

### DIFF
--- a/easy_thumbnails/source_generators.py
+++ b/easy_thumbnails/source_generators.py
@@ -31,14 +31,15 @@ def pil_image(source, exif_orientation=True, **options):
 
     image = Image.open(source)
     # Fully load the image now to catch any problems with the image contents.
-    try:
-        # An "Image file truncated" exception can occur for some images that
-        # are still mostly valid -- we'll swallow the exception.
-        image.load()
-    except IOError:
-        pass
-    # Try a second time to catch any other potential exceptions.
-    image.load()
+    for _ in range(5):
+        try:
+            # An "Image file truncated" exception can occur for some images that
+            # are still mostly valid -- we'll swallow the exception.
+            image.load()
+        except IOError:
+            continue
+        else:
+            break
 
     if exif_orientation:
         image = utils.exif_orientation(image)


### PR DESCRIPTION
As of version 6.1.0, the Pillow imaging library’s C module includes an optimized native entropy method:

• https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst#610-2019-07-01

This change detects and selects this new native method, if it is available in the version of Pillow upon which `easy-thumbnails` finds itself running.

Additionally, an optimized version of the existing Python image-entropy method is furnished as a fallback: rather than summing the entire histogram value set, this new function calculates the product of the image dimensions and band count, arriving at the same number. The new function also uses generator expressions and the specialized `math.fsum(…)` and `math.log2(…)` library calls to improve on the performance of its predecessor without altering the algorithm.

The appropriate image-entropy function is then conditionally ensconced in the `easy_thumbnails.utils` module, at module-load time.

I also made a slight tweak to the `pil_image` function, found in `easy_thumbnails.source_generators` – the call to `PIL.Image.Image.load()` was raising the exception noted in comments in that functions’ source while I was running the testsuite; now all such calls have these exceptions swallowed and everything works OK.