### PR TITLE
add alias name to the thumbnail options (fixes #543)

### DIFF
--- a/easy_thumbnails/files.py
+++ b/easy_thumbnails/files.py
@@ -337,6 +337,7 @@ class Thumbnailer(File):
         options = aliases.get(alias, target=self.alias_target)
         if not options:
             raise KeyError(alias)
+        options['ALIAS'] = alias
         return self.get_thumbnail(options, silent_template_exception=True)
 
     def get_options(self, thumbnail_options, **kwargs):


### PR DESCRIPTION
Fixes  #543 Adds missing 'ALIAS' key in thumbnail options and enables namers to access the alias name, like the built in `easy_thumbnailer.namer.alias` that didn't work before.