### PR TITLE
Fix long names thumbnail

### DIFF
--- a/easy_thumbnails/files.py
+++ b/easy_thumbnails/files.py
@@ -450,6 +450,16 @@ class Thumbnailer(File):
             thumbnail_options=thumbnail_options,
             prepared_options=prepared_opts,
         )
+        max_length = models.File._meta.get_field('name').max_length
+        if len(filename) > max_length:
+            additional_length = len(filename) - max_length
+            filename = namer_func(
+                thumbnailer=self,
+                source_filename=source_filename[::additional_length],
+                thumbnail_extension=extension,
+                thumbnail_options=thumbnail_options,
+                prepared_options=prepared_opts,
+            )
         if high_resolution:
             filename = self.thumbnail_highres_infix.join(
                 os.path.splitext(filename))

--- a/easy_thumbnails/files.py
+++ b/easy_thumbnails/files.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 
 from django.core.files.base import File, ContentFile
@@ -453,10 +454,11 @@ class Thumbnailer(File):
         max_length = models.File._meta.get_field('name').max_length
         if len(filename) > max_length:
             length_total = len(filename) + len(self.thumbnail_highres_infix) + len(self.thumbnail_prefix)
-            additional_length = length_total - max_length
+            additional_length = length_total + 32 - max_length
             filename = namer_func(
                 thumbnailer=self,
-                source_filename=source_filename[:-additional_length],
+                source_filename='%s%s' % (source_filename[:-additional_length],
+                                          hashlib.md5(source_filename.encode('utf-8')).hexdigest()),
                 thumbnail_extension=extension,
                 thumbnail_options=thumbnail_options,
                 prepared_options=prepared_opts,

--- a/easy_thumbnails/files.py
+++ b/easy_thumbnails/files.py
@@ -452,10 +452,11 @@ class Thumbnailer(File):
         )
         max_length = models.File._meta.get_field('name').max_length
         if len(filename) > max_length:
-            additional_length = len(filename) - max_length
+            length_total = len(filename) + len(self.thumbnail_highres_infix) + len(self.thumbnail_prefix)
+            additional_length = length_total - max_length
             filename = namer_func(
                 thumbnailer=self,
-                source_filename=source_filename[::additional_length],
+                source_filename=source_filename[:-additional_length],
                 thumbnail_extension=extension,
                 thumbnail_options=thumbnail_options,
                 prepared_options=prepared_opts,

--- a/easy_thumbnails/tests/test_files.py
+++ b/easy_thumbnails/tests/test_files.py
@@ -106,6 +106,26 @@ class FilesTest(test.BaseTest):
             '<img alt="" class="fish" height="75" rel="A&amp;B" '
             'src="%s" width="100" />' % local.url)
 
+    def test_tag_long_filename_multiple_same_names(self):
+        local = self.longname_thumbnailer.get_thumbnail({'size': (100, 100)})
+        long_filename_2 = self.create_image(self.storage, '%s.jpg' % ('*' * 250))
+        longname_thumbnailer_2 = files.get_thumbnailer(self.storage, long_filename_2)
+        longname_thumbnailer_2.thumbnail_storage = self.storage
+        local_2 = longname_thumbnailer_2.get_thumbnail({'size': (100, 100)})
+        self.assertEqual(
+            local.tag(), '<img alt="" height="75" src="%s" width="100" '
+                         '/>' % local.url)
+        self.assertEqual(
+            local.tag(alt='A & B'), '<img alt="A &amp; B" height="75" '
+                                    'src="%s" width="100" />' % local.url)
+        self.assertEqual(
+            local_2.tag(), '<img alt="" height="75" src="%s" width="100" '
+                           '/>' % local_2.url)
+        self.assertEqual(
+            local_2.tag(alt='A & B'), '<img alt="A &amp; B" height="75" '
+                                      'src="%s" width="100" />' % local_2.url)
+        self.assertNotEqual(local_2.url, local.url)
+
     def test_tag_long_filename(self):
         local = self.longname_thumbnailer.get_thumbnail({'size': (100, 100)})
         remote = self.longname_remote_thumbnailer.get_thumbnail({'size': (100, 100)})


### PR DESCRIPTION
- Do not use hash for SEO
- Truncate end of the file after generate thumbnail
- Add tests with long names

#388