### PR TITLE
THUMBNAIL_IMAGE_SAVE_OPTIONS. See #583

### DIFF
--- a/easy_thumbnails/conf.py
+++ b/easy_thumbnails/conf.py
@@ -309,4 +309,17 @@ class Settings(AppSettings):
     :class:`easy_thumbnails.widgets.ImageClearableFileInput` widget.
     """
 
+    THUMBNAIL_IMAGE_SAVE_OPTIONS = {
+        'JPEG': {
+            'quality': 85,
+        },
+        'WEBP': {
+            'quality': 85,
+        },
+    }
+    """
+    Allows customising Image.save parameters based on format, for example:
+    `{'WEBP': {'method': 6}}`
+    """
+
 settings = Settings()

--- a/easy_thumbnails/engine.py
+++ b/easy_thumbnails/engine.py
@@ -46,8 +46,9 @@ def save_pil_image(image, destination=None, filename=None, **options):
     # Ensure plugins are fully loaded so that Image.EXTENSION is populated.
     Image.init()
     format = Image.EXTENSION.get(os.path.splitext(filename)[1].lower(), 'JPEG')
-    if format in ('JPEG', 'WEBP'):
-        options.setdefault('quality', 85)
+    if format in settings.THUMBNAIL_IMAGE_SAVE_OPTIONS:
+        for key, value in settings.THUMBNAIL_IMAGE_SAVE_OPTIONS[format].items():
+            options.setdefault(key, value)
     saved = False
     if format == 'JPEG':
         if image.mode.endswith('A'):


### PR DESCRIPTION
Simple workaround that allows injecting options into `Image.save`. See #583 