### PR TITLE
Require [svg] extra for SVG support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ __ http://easy-thumbnails.readthedocs.org/en/latest/index.html
 Breaking News
 =============
 
-Version 2.8.0 adds support for thumbnailing SVG images.
+Version 2.8.0 adds support for thumbnailing SVG images when installed with the ``[svg]`` extra.
 
 Of course it doesn't make sense to thumbnail SVG images, because being in vector format they can
 scale to any size without quality of loss. However, users of easy-thumbnails may want to upload and

--- a/docs/ref/svg.rst
+++ b/docs/ref/svg.rst
@@ -21,4 +21,6 @@ images and hence can be used by third-party apps such as
 
 Since easy-thumbnails version 2.8, you can therefore use an SVG image, just as you would use any other image.
 
+This requires easy-thumbnails to have been installed with the ``[svg]`` extra enabled.
+
 Cropping an SVG image works as expected. Filtering an SVG image will however not work.

--- a/easy_thumbnails/source_generators.py
+++ b/easy_thumbnails/source_generators.py
@@ -1,3 +1,4 @@
+import warnings
 from io import BytesIO
 
 from easy_thumbnails import utils
@@ -40,7 +41,11 @@ def vil_image(source, **options):
     """
     Try to open the source file directly using VIL, ignoring any errors.
     """
-    from easy_thumbnails.VIL import Image
+    try:
+        from easy_thumbnails.VIL import Image
+    except ImportError as ie:
+        warnings.warn(f"Could not import VIL for SVG image support: {ie}.")
+        return
 
     if not source:
         return

--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,13 @@ setup(
     install_requires=[
         "django>=2.2",
         "pillow",
-        "svglib",
-        "reportlab",
     ],
+    extras_require={
+        "svg": [
+            "svglib",
+            "reportlab",
+        ],
+    },
     python_requires=">=3.6",
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ python =
 setenv =
     DJANGO_SETTINGS_MODULE=easy_thumbnails.tests.settings
 usedevelop = True
+extras = svg
 deps =
     django22: Django<2.3
     django30: Django<3.1


### PR DESCRIPTION
This PR gates SVG support behind the `[svg]` install extra.

With that, there is no hard dependency on `svglib` and `reportlab` (see #591).

The `vil_image` generator will emit a warning if it fails to import the VIL bits.