### PR TITLE
fix: remove THUMBNAIL_HIGH_RESOLUTION and THUMBNAIL_HIGHRES_INFIX settings (#584)

### DIFF
--- a/easy_thumbnails/conf.py
+++ b/easy_thumbnails/conf.py
@@ -16,16 +16,9 @@ class AppSettings(BaseSettings):
     """
 
     def __init__(self, isolated=False, *args, **kwargs):
-        import warnings
-
         self.isolated = isolated
         self._changed = {}
         self._added = []
-        if django_settings.configured:
-            if hasattr(django_settings, 'THUMBNAIL_HIGH_RESOLUTION'):
-                warnings.warn("THUMBNAIL_HIGH_RESOLUTION is unused and now obsolete.", DeprecationWarning)
-            if hasattr(django_settings, 'THUMBNAIL_HIGHRES_INFIX'):
-                warnings.warn("THUMBNAIL_HIGHRES_INFIX is unused and now obsolete.", DeprecationWarning)
 
     def get_isolated(self):
         return self._isolated

--- a/easy_thumbnails/templatetags/thumbnail.py
+++ b/easy_thumbnails/templatetags/thumbnail.py
@@ -17,7 +17,6 @@ RE_SIZE = re.compile(r'(\d+)x(\d+)$')
 
 VALID_OPTIONS = utils.valid_processor_options()
 VALID_OPTIONS.remove('size')
-VALID_OPTIONS.append('HIGH_RESOLUTION')
 
 
 def split_args(args):

--- a/easy_thumbnails/tests/test_templatetags.py
+++ b/easy_thumbnails/tests/test_templatetags.py
@@ -148,6 +148,9 @@ class ThumbnailTagTest(Base):
         settings.THUMBNAIL_DEBUG = True
         self.assertRaises(TemplateSyntaxError, self.render_template, src)
 
+        src = '{% thumbnail source 240x240 HIGH_RESOLUTION %}'
+        self.assertRaises(TemplateSyntaxError, self.render_template, src)
+
     def testTag(self):
         # Set THUMBNAIL_DEBUG = True to make it easier to trace any failures
         settings.THUMBNAIL_DEBUG = True


### PR DESCRIPTION
Fixes https://github.com/SmileyChris/easy-thumbnails/issues/584

In easy-thumbnails 2.8 support for high resolution images (THUMBNAIL_HIGH_RESOLUTION and THUMBNAIL_HIGHRES_INFIX settings) and I believe HIGH_RESOLUTION argument for thumbnail tag has also been removed.

This removes specified settings and raises an error if they are used.