### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/ref/webp.rst
+++ b/docs/ref/webp.rst
@@ -68,6 +68,6 @@ In the future, Easy Thumbnails might support WebP natively. This however means t
 be usable as ``<img ...>`` -tag, supported by all browsers, and fully integrated into tools
 such as django-filer_.
 
-Until that happens, I reccomend to proceed with the workarround described here.
+Until that happens, I recommend to proceed with the workarround described here.
 
 .. _django-filer: https://django-filer.readthedocs.io/en/latest/

--- a/easy_thumbnails/tests/test_files.py
+++ b/easy_thumbnails/tests/test_files.py
@@ -286,7 +286,7 @@ class FilesTest(test.BaseTest):
         opts = {'size': (50, 50)}
         thumb = self.thumbnailer.get_thumbnail(opts)
         self.assertEqual((thumb.width, thumb.height), (50, 38))
-        # Now the thumb has been created, check that dimesions are in the
+        # Now the thumb has been created, check that dimensions are in the
         # database.
         dimensions = models.ThumbnailDimensions.objects.all()[0]
         self.assertEqual(


### PR DESCRIPTION
There are small typos in:
- docs/ref/webp.rst
- easy_thumbnails/tests/test_files.py

Fixes:
- Should read `recommend` rather than `reccomend`.
- Should read `dimensions` rather than `dimesions`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md