### PR TITLE
Tiff upload

### DIFF
--- a/easy_thumbnails/engine.py
+++ b/easy_thumbnails/engine.py
@@ -67,6 +67,9 @@ def save_pil_image(image, destination=None, filename=None, **options):
             # shouldn't be triggered very often these days, as recent versions
             # of pillow avoid the MAXBLOCK limitation.
             pass
+    else:
+        if 'quality' in options:
+            options.pop('quality')
     if not saved:
         image.save(destination, format=format, **options)
     if hasattr(destination, 'seek'):

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 distribute = False
 envlist =
     py{36,37,38,39}-django{22,30,31,32}{-svg,}
-    py310-django{32,40}{-svg,}
+    py310-django{32,40,41}{-svg,}
 skip_missing_interpreters = True
 
 [gh-actions]
@@ -25,6 +25,7 @@ deps =
     django31: Django<3.2
     django32: Django<3.3
     django40: Django<4.1
+    django41: Django<4.2
     testfixtures
 commands =
     python -Wd {envbindir}/django-admin test {posargs}


### PR DESCRIPTION
when uploading TIFF images, easy-thumbnails adds argument `quality` when creating the thumbnail.
The `PIL/TiffImagePlugin` doesn't like that.