### PR TITLE
Parameter 'quality' is not passed to pillow if WEBP format is used

### DIFF
--- a/easy_thumbnails/engine.py
+++ b/easy_thumbnails/engine.py
@@ -67,7 +67,7 @@ def save_pil_image(image, destination=None, filename=None, **options):
             # shouldn't be triggered very often these days, as recent versions
             # of pillow avoid the MAXBLOCK limitation.
             pass
-    else:
+    elif format != 'WEBP':
         if 'quality' in options:
             options.pop('quality')
     if not saved:

--- a/easy_thumbnails/engine.py
+++ b/easy_thumbnails/engine.py
@@ -67,9 +67,8 @@ def save_pil_image(image, destination=None, filename=None, **options):
             # shouldn't be triggered very often these days, as recent versions
             # of pillow avoid the MAXBLOCK limitation.
             pass
-    elif format != 'WEBP':
-        if 'quality' in options:
-            options.pop('quality')
+    elif format == 'TIFF':
+        options.pop('quality', None)
     if not saved:
         image.save(destination, format=format, **options)
     if hasattr(destination, 'seek'):


### PR DESCRIPTION
After commit https://github.com/SmileyChris/easy-thumbnails/commit/7b9719e379916b19945623b8d3299a279e38c395, parameter 'quality' is not passed to pillow for any format except of 'JPEG'.