### PR TITLE
Fix #622 address ZeroDivisionError in scale_and_crop.

### DIFF
--- a/easy_thumbnails/processors.py
+++ b/easy_thumbnails/processors.py
@@ -174,9 +174,15 @@ def scale_and_crop(im, size, crop=False, upscale=False, zoom=None, target=None,
     target_x, target_y = [int(v) for v in size]
 
     if crop or not target_x or not target_y:
-        scale = max(target_x / source_x, target_y / source_y)
+        scale = max(
+            1.0 if source_x == 0 else target_x / source_x,
+            1.0 if source_y == 0 else target_y / source_y,
+        )
     else:
-        scale = min(target_x / source_x, target_y / source_y)
+        scale = min(
+            1.0 if source_x == 0 else target_x / source_x,
+            1.0 if source_y == 0 else target_y / source_y,
+        )
 
     # Handle one-dimensional targets.
     if not target_x:

--- a/easy_thumbnails/tests/test_svg_processors.py
+++ b/easy_thumbnails/tests/test_svg_processors.py
@@ -31,6 +31,10 @@ class ScaleAndCropTest(unittest.TestCase):
         self.assertEqual(upscaled.size, (1000, 750))
         self.assertEqual(upscaled.getbbox(), (0, 0, 800, 600))
 
+        empty = processors.scale_and_crop(create_image(size=(0, 0)), (1000, 1000))
+        self.assertEqual(empty.size, (0, 0))
+        self.assertEqual(empty.getbbox(), (0, 0, 0, 0))
+
     def test_crop(self):
         image = create_image()
 
@@ -49,3 +53,9 @@ class ScaleAndCropTest(unittest.TestCase):
         upscaled = processors.scale_and_crop(image, (1000, 1000), crop=True, upscale=True)
         self.assertEqual(upscaled.size, (1000, 1000))
         self.assertEqual(upscaled.getbbox(), (100, 0, 600, 600))
+
+        empty = processors.scale_and_crop(
+            create_image(size=(0, 0)), (1000, 1000), crop=True
+        )
+        self.assertEqual(empty.size, (0, 0))
+        self.assertEqual(empty.getbbox(), (0, 0, 0, 0))


### PR DESCRIPTION
Set X or Y scale to 1.0 when corresponding source size is 0.