### PR TITLE
Fix tests broken by fixes of CVE-2024-39330

### DIFF
--- a/easy_thumbnails/files.py
+++ b/easy_thumbnails/files.py
@@ -422,6 +422,10 @@ class Thumbnailer(File):
         """
         thumbnail_options = self.get_options(thumbnail_options)
         path, source_filename = os.path.split(self.name)
+        # remove storage location
+        path = path.replace(self.source_storage.location, '')
+        # remove leading slash if present
+        path = path.lstrip('/')
         source_extension = os.path.splitext(source_filename)[1][1:].lower()
         preserve_extensions = self.thumbnail_preserve_extensions
         if preserve_extensions is True or isinstance(preserve_extensions, (list, tuple)) and \


### PR DESCRIPTION
This fixes the tests broken by updating to Django 4.2.14 (and other last patch versions).

This modifies the ` get_thumbnail_name()` to delete storage location from the path in filename. I hope this is the correct fix. @bmihelac Can you please check and review?