### PR TITLE
Test/test improvements

### DIFF
--- a/TESTING.rst
+++ b/TESTING.rst
@@ -14,5 +14,5 @@ pytest
 ------
 
 Assuming you're just wanting to test the current development version against
-your virtualenv setup, you can alternatively just ``pip install pytest-django``
+your virtualenv setup, you can alternatively just ``pip install pytest-django testfixtures``
 and run ``pytest``.

--- a/easy_thumbnails/tests/test_files.py
+++ b/easy_thumbnails/tests/test_files.py
@@ -7,10 +7,7 @@ from easy_thumbnails.conf import settings
 from easy_thumbnails.options import ThumbnailOptions
 from easy_thumbnails.tests import utils as test
 from PIL import Image
-try:
-    from testfixtures import LogCapture
-except ImportError:
-    LogCapture = None
+from testfixtures import LogCapture
 import unittest
 
 

--- a/easy_thumbnails/tests/test_files.py
+++ b/easy_thumbnails/tests/test_files.py
@@ -211,7 +211,6 @@ class FilesTest(test.BaseTest):
     @unittest.skipIf(
         'easy_thumbnails.optimize' not in settings.INSTALLED_APPS,
         'optimize app not installed')
-    @unittest.skipIf(LogCapture is None, 'testfixtures not installed')
     def test_postprocessor(self):
         """use a mock image optimizing post processor doing nothing"""
         settings.THUMBNAIL_OPTIMIZE_COMMAND = {
@@ -219,7 +218,7 @@ class FilesTest(test.BaseTest):
         with LogCapture() as logcap:
             self.ext_thumbnailer.thumbnail_extension = 'png'
             self.ext_thumbnailer.get_thumbnail({'size': (10, 10)})
-            actual = tuple(logcap.actual())[0]
+            actual = tuple(logcap.actual())[-1]
             self.assertEqual(actual[0], 'easy_thumbnails.optimize')
             self.assertEqual(actual[1], 'INFO')
             self.assertRegex(
@@ -237,7 +236,7 @@ class FilesTest(test.BaseTest):
         with LogCapture() as logcap:
             self.ext_thumbnailer.thumbnail_extension = 'png'
             self.ext_thumbnailer.get_thumbnail({'size': (10, 10)})
-            actual = tuple(logcap.actual())[0]
+            actual = tuple(logcap.actual())[-1]
             self.assertEqual(actual[0], 'easy_thumbnails.optimize')
             self.assertEqual(actual[1], 'ERROR')
             self.assertRegex(


### PR DESCRIPTION
1. Testing in a local environment would skip a few tests when the testfixtures package is missing. The documentation has been updated to mention that installing testfixtures is not optional for the tests anymore.
2. `LogCapture`  could have more log records (ie some warnings); handling in the test is changed to check the last message instead of the first one.