### PR TITLE
Ensure FIPS compliance by marking MD5 and SHA-1 as non-security-related

### DIFF
--- a/easy_thumbnails/namers.py
+++ b/easy_thumbnails/namers.py
@@ -2,6 +2,8 @@ import base64
 import hashlib
 import os
 
+from easy_thumbnails.utils import sha1_not_used_for_security
+
 
 def default(thumbnailer, prepared_options, source_filename,
             thumbnail_extension, **kwargs):
@@ -38,7 +40,7 @@ def hashed(source_filename, prepared_options, thumbnail_extension, **kwargs):
     for example: ``6qW1buHgLaZ9.jpg``.
     """
     parts = ':'.join([source_filename] + prepared_options)
-    short_sha = hashlib.sha1(parts.encode('utf-8')).digest()
+    short_sha = sha1_not_used_for_security(parts.encode('utf-8')).digest()
     short_hash = base64.urlsafe_b64encode(short_sha[:9]).decode('utf-8')
     return '.'.join([short_hash, thumbnail_extension])
 
@@ -54,10 +56,10 @@ def source_hashed(source_filename, prepared_options, thumbnail_extension,
     base64 sha1 hash of the thumbnail options. For example:
     ``1xedFtqllFo9_100x100_QHCa6G1l.jpg``.
     """
-    source_sha = hashlib.sha1(source_filename.encode('utf-8')).digest()
+    source_sha = sha1_not_used_for_security(source_filename.encode('utf-8')).digest()
     source_hash = base64.urlsafe_b64encode(source_sha[:9]).decode('utf-8')
     parts = ':'.join(prepared_options[1:])
-    parts_sha = hashlib.sha1(parts.encode('utf-8')).digest()
+    parts_sha = sha1_not_used_for_security(parts.encode('utf-8')).digest()
     options_hash = base64.urlsafe_b64encode(parts_sha[:6]).decode('utf-8')
     return '%s_%s_%s.%s' % (
         source_hash, prepared_options[0], options_hash, thumbnail_extension)

--- a/easy_thumbnails/namers.py
+++ b/easy_thumbnails/namers.py
@@ -1,5 +1,4 @@
 import base64
-import hashlib
 import os
 
 from easy_thumbnails.utils import sha1_not_used_for_security

--- a/easy_thumbnails/utils.py
+++ b/easy_thumbnails/utils.py
@@ -65,7 +65,7 @@ def get_storage_hash(storage):
     if not isinstance(storage, str):
         storage_cls = storage.__class__
         storage = '%s.%s' % (storage_cls.__module__, storage_cls.__name__)
-    return hashlib.md5(storage.encode('utf8')).hexdigest()
+    return md5_not_used_for_security(storage.encode('utf8')).hexdigest()
 
 
 def is_transparent(image):
@@ -145,3 +145,19 @@ def get_modified_time(storage, name):
             default_timezone = timezone.get_default_timezone()
             return timezone.make_aware(modified_time, default_timezone)
     return modified_time
+
+def md5_not_used_for_security(data):
+    """
+    Calculate a md5 hash of the given data, but explicitly mark it as not
+    being used for security purposes. Without this flag FIPS compliant
+    systems will raise an exception when used.
+    """
+    return hashlib.new('md5', data, usedforsecurity=False)
+
+def sha1_not_used_for_security(data):
+    """
+    Calculate a sha1 hash of the given data, but explicitly mark it as not
+    being used for security purposes. Without the flag FIPS compliant
+    systems will raise an exception when used.
+    """
+    return hashlib.new('sha1', data, usedforsecurity=False)


### PR DESCRIPTION
This update addresses issues with environments that enforce FIPS standards by preventing non-compliant algorithms (like MD5 and SHA-1) from being used in contexts related to security. Since these hashes do not involve sensitive data they should be explicitly marked as not used for security.

The easiest syntax change would be to just add a kwarg to calls.
`short_sha = hashlib.sha1(parts.encode('utf-8', usedforsecurity=False))`
 Unfortunately that's not compatible with Python <3.9.

Alternative solution to this problem could be switching to sha-256 hashes everywhere.
Alternative implementation could be:
```
def md5_not_usedforsecurity(data):
    try:
        return hashlib.md5(data, usedforsecurity=False).hexdigest()
    except TypeError:
        return hashlib.md5(data).hexdigest()
```

Context:
https://github.com/python/cpython/issues/53462#issuecomment-1093510111