### PR TITLE
Add support for Python 3.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Software Development :: Libraries :: Application Frameworks",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ distribute = False
 envlist =
     py{38,39,310,311,312}-django42{-svg,}
     py{310,311,312}-django50{-svg,}
-    py{310,311,312}-django51{-svg,}
+    py{310,311,312,313}-django51{-svg,}
 skip_missing_interpreters = True
 
 [gh-actions]
@@ -12,6 +12,7 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [testenv]
 setenv =


### PR DESCRIPTION
This PR replaces `imghdr.what()` with PIL to determine the file format of a thumbnail in the optimization callback.

Closes #631 