### PR TITLE
Add support for Django 5.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
         "Framework :: Django :: 5.1",
+        "Framework :: Django :: 5.2",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         "Environment :: Web Environment",
         "Framework :: Django",
         "Framework :: Django :: 4.2",
-        "Framework :: Django :: 5.0",
         "Framework :: Django :: 5.1",
         "Framework :: Django :: 5.2",
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py{39,310,311,312}-django42{-svg,}
     py{310,311,312}-django50{-svg,}
     py{310,311,312,313}-django51{-svg,}
+    py{310,311,312,313}-django52{-svg,}
 skip_missing_interpreters = True
 
 [gh-actions]
@@ -24,6 +25,7 @@ deps =
     django42: Django<4.3
     django50: Django<5.1
     django51: Django>=5.1,<5.2
+    django52: Django>=5.2,<6.0
     testfixtures
     coverage
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 distribute = False
 envlist =
-    py{38,39,310,311,312}-django42{-svg,}
+    py{39,310,311,312}-django42{-svg,}
     py{310,311,312}-django50{-svg,}
     py{310,311,312,313}-django51{-svg,}
 skip_missing_interpreters = True

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 distribute = False
 envlist =
     py{39,310,311,312}-django42{-svg,}
-    py{310,311,312}-django50{-svg,}
     py{310,311,312,313}-django51{-svg,}
     py{310,311,312,313}-django52{-svg,}
 skip_missing_interpreters = True
@@ -23,7 +22,6 @@ extras =
     svg: svg
 deps =
     django42: Django<4.3
-    django50: Django<5.1
     django51: Django>=5.1,<5.2
     django52: Django>=5.2,<6.0
     testfixtures


### PR DESCRIPTION
Hi there - I'm keen to see a new release so we can run this on Python 3.13 projects... but that also means the project needs a quick update to support Django 5.2 as well.

I've dropped Django 5.0 as part of this, as it's EOL.